### PR TITLE
feat: ADR-300 field discovery with tiered promotion

### DIFF
--- a/docs/architecture/api/ADR-300-field-discovery-with-tiered-promotion-and-catalog-resources.md
+++ b/docs/architecture/api/ADR-300-field-discovery-with-tiered-promotion-and-catalog-resources.md
@@ -28,13 +28,34 @@ Implement a two-tier field discovery system that runs at server startup (async, 
 
 Fields that pass qualification and meet a usage threshold. These are surfaced proactively in tool schemas, next-steps suggestions, and the field catalog resource.
 
-**Qualification pipeline:**
+**Discovery pipeline:**
 
-1. **Describe** — fetch field metadata for core objects (Account, Opportunity, Contact, Lead, Contract, ContentVersion, plus any objects seen in recent queries)
-2. **Quality gate** — exclude fields with no label beyond the API name and no help text (the Salesforce equivalent of Jira's "no description" filter)
-3. **Usage scoring** — for custom fields, run a sampling query: `SELECT {field}, COUNT(Id) FROM {Object} WHERE {field} != null GROUP BY {field}` to estimate population density
-4. **Tail-curve cutoff** — find the knee in the usage distribution (largest relative drop between adjacent fields) to automatically cap promoted fields. Hard cap at ~40 fields per object.
-5. **Well-known field resolution** — for fields with known semantic meaning but variable names (e.g., "latest version" boolean on ContentVersion), resolve by matching label patterns and field type rather than hardcoding API names
+1. **Describe** — fetch field metadata for core objects (Account, Opportunity, Contact, Lead, Contract, ContentVersion, plus any objects seen in recent queries). Parallel with bounded concurrency (default: 3).
+2. **Type classification** — use `field-type-map.ts` to classify each field into computation categories (numeric, categorical, text, temporal, identifier, flag, compound, binary). The `isScorable()` function determines which fields can be population-scored.
+3. **Usage scoring** — for scorable fields, run `SELECT COUNT(Id) FROM {Object} WHERE {field} != null` with rate-limited parallel execution (default: 5 concurrent) and exponential backoff on 429s.
+
+**Regulator pipeline (scoring):**
+
+After raw population scores are collected, a composable `FieldRegulator` applies scoring adjustments. Each regulator is a pure function that takes a field + context and returns a score delta with a reason. Regulators stack — order doesn't matter, all run on every field.
+
+| Regulator | Signal | Effect |
+|-----------|--------|--------|
+| `population` | `WHERE field != null` count | Base score (0-100) |
+| `namespace` | Managed package prefix (`DOZISF__`, `adroll__`, etc.) | -20 to -40 penalty |
+| `labelDemotion` | "Deprecated", "DO NOT USE", `z[` prefix, `TECH` prefix | -30 to -80 penalty |
+| `qualityBoost` | Has help text | +15 boost |
+| `typeRelevance` | Categorical/numeric fields more analytically useful | +5 to +10 boost |
+| `autoPopulated` | System/formula fields (PhotoUrl, Record_ID, etc.) | -50 penalty |
+
+The regulator stack is extensible — new regulators (e.g., recency weighting) can be added without modifying existing ones. Each field's final score includes an audit trail of all adjustments, making promotion decisions transparent and debuggable.
+
+**Promotion cutoff:**
+
+After regulation, fields are ranked by composite score. The cutoff uses the tail-curve knee (largest relative score drop) with a hard cap (default: 40 per object). Fields with score ≤ 0 are never promoted regardless of position.
+
+**Well-known field resolution:**
+
+Fields with known semantic meaning but variable API names (e.g., "latest version" boolean on ContentVersion) are resolved by label pattern + field type matching rather than hardcoding names.
 
 ### Tier 2: Discoverable fields
 
@@ -56,17 +77,25 @@ Expose discovery results as MCP resources for agent elicitation (extends ADR-103
 
 These resources give the agent a pre-filtered, ranked view of what fields matter on an object before it writes a SOQL query — reducing round-trips and improving query accuracy.
 
+### Context explosion controls
+
+Discovery can produce hundreds of promoted fields across multiple objects. Uncontrolled injection into tool schemas would create context pressure — the cure worse than the disease. Defense is layered:
+
+| Layer | Control | Scope |
+|-------|---------|-------|
+| Field scoring | Regulator pipeline (negative scores never promote) | Per field |
+| Object cap | Hard cap + knee cutoff (default: 40 per object) | Per object |
+| Startup scope | Core objects only; others discovered on-demand | Per session |
+| Schema budget | Tool descriptions get summary only; full catalog in resources | Per tool call |
+| Global budget | Total promoted field count cap across all objects (default: 200) | Per server |
+
+**Schema vs resource split:** Tool descriptions include a brief summary ("Account: 35 promoted fields — read `salesforce://field-catalog/Account` for details"). The full ranked catalog lives in MCP resources, which agents pull on-demand. This keeps `ListTools` responses small regardless of org complexity.
+
+**Internal field resolution:** Code that needs specific field names (like `downloadFile` resolving "latest version" boolean) queries the discovery cache directly — no schema injection needed. This is a lookup, not a context expansion.
+
 ### Async tool property factory
 
-Discovery results feed back into tool registration. When the server registers tools via `ListTools`, promoted fields are injected into tool schemas dynamically:
-
-- `execute_soql` schema gains per-object field hints in its description: "Opportunity promoted fields: Amount, StageName, CloseDate, Custom_Revenue__c..."
-- `describe_object` includes promotion status and usage scores alongside standard metadata
-- Internal field references (like "latest version" boolean in `downloadFile`) resolve through the factory rather than hardcoding API names
-
-The factory runs after discovery completes. If discovery hasn't finished when `ListTools` is called, the server returns base schemas (current behavior). Once discovery completes, subsequent `ListTools` calls return enriched schemas. This is transparent to the agent — it just sees better tool descriptions over time.
-
-This is distinct from the catalog resource: the resource is agent-readable context for planning; the factory is machine-readable schema that shapes what the agent can express in tool calls.
+After discovery completes, tool descriptions are enriched with per-object summaries and field counts. If discovery hasn't finished when `ListTools` is called, the server returns base schemas (current behavior). This is transparent to the agent — it just sees better tool descriptions over time.
 
 ### Startup and caching
 
@@ -107,6 +136,26 @@ This gives transparency into filtering decisions and helps diagnose issues when 
 - `describe_object` continues to work as-is for ad-hoc exploration
 - Existing tool schemas don't change — promoted fields enhance suggestions, not restrict access
 - The field catalog resource enables but doesn't require elicitation workflows
+
+## Experimental Validation
+
+Validated against Praecipio's production Salesforce org (6 core objects, 665 total fields). Experiment code in `experiments/` on the `experiment/field-discovery-validation` branch.
+
+| Hypothesis | Result | Data |
+|-----------|--------|------|
+| H1: Describe latency | **PASS** | 6.1s total with 3-concurrent parallelism. Each describe ~300-430ms. |
+| H2: Quality gate | **PASS** | 49% of fields pass (help text + meaningful label). Filters meaningfully without being too aggressive. |
+| H3: Usage scoring | **PASS** | 0 errors after using `isScorable()` type classification to exclude compound, binary, textarea, identifier types. |
+| H4: Tail-curve cutoff | **PASS** | Clear knee on every object. ContentVersion: 10 promoted. Contact: 32. Account/Opportunity hit 40-field hard cap. |
+| H5: Well-known resolution | **PASS** | `ContentVersion.IsLatest` found by label "Is Latest" + type `boolean`. |
+| H6: Regulator pipeline | **PASS** | Correctly demotes: managed packages (adroll__ -80), deprecated labels (-80), auto-populated system fields (-50), TECH prefix (-30). Correctly boosts: help text (+15), categorical/numeric types (+10). |
+
+### Key findings
+
+- **Type classification is the bridge.** The existing `field-type-map.ts` (ADR-101) already classifies every Salesforce type. Adding `isScorable()` eliminated all 24 scoring errors from the initial probe run — compound addresses, long text, and binary fields are excluded cleanly.
+- **Regulators catch what population misses.** `adroll__Click_Conversion__c` was 100% populated but correctly scored -10 (managed package penalty + deprecated label). `PhotoUrl` was 100% populated but dropped to score 50 (auto-populated penalty).
+- **Concurrency controls work.** 3-concurrent describes + 5-concurrent scoring queries completed in 6s with zero 429s. Exponential backoff with jitter is available but wasn't triggered at this concurrency level.
+- **Messy org defense.** The namespace regulator, label demotion, and auto-populated detection together handle the "500 fields from 5 managed packages" scenario — junk fields score negative regardless of population density.
 
 ## Alternatives Considered
 

--- a/docs/architecture/api/ADR-300-field-discovery-with-tiered-promotion-and-catalog-resources.md
+++ b/docs/architecture/api/ADR-300-field-discovery-with-tiered-promotion-and-catalog-resources.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-03-25
 deciders:
   - aaronsb

--- a/src/__tests__/field-regulator.test.ts
+++ b/src/__tests__/field-regulator.test.ts
@@ -1,0 +1,188 @@
+import {
+  scoreField, regulateFields,
+  populationRegulator, namespaceRegulator, labelDemotionRegulator,
+  qualityBoostRegulator, typeRelevanceRegulator, autoPopulatedRegulator,
+  FieldCandidate,
+} from '../utils/field-regulator.js';
+
+function makeField(overrides: Partial<FieldCandidate> = {}): FieldCandidate {
+  return {
+    name: 'TestField__c',
+    label: 'Test Field',
+    type: 'string',
+    custom: true,
+    helpText: null,
+    nillable: true,
+    computationType: 'text',
+    ...overrides,
+  };
+}
+
+describe('populationRegulator', () => {
+  it('should return population percentage as score', () => {
+    const adj = populationRegulator(makeField({ populationPct: 75 }));
+    expect(adj?.delta).toBe(75);
+    expect(adj?.regulator).toBe('population');
+  });
+
+  it('should return null when populationPct is undefined', () => {
+    expect(populationRegulator(makeField())).toBeNull();
+  });
+
+  it('should return 0 for empty fields', () => {
+    const adj = populationRegulator(makeField({ populationPct: 0 }));
+    expect(adj?.delta).toBe(0);
+  });
+});
+
+describe('namespaceRegulator', () => {
+  it('should penalize managed package fields', () => {
+    const adj = namespaceRegulator(makeField({ name: 'DOZISF__ZoomInfo_Id__c' }));
+    expect(adj?.delta).toBeLessThan(0);
+    expect(adj?.reason).toContain('DOZISF');
+  });
+
+  it('should not penalize org-owned custom fields', () => {
+    expect(namespaceRegulator(makeField({ name: 'My_Custom__c' }))).toBeNull();
+  });
+
+  it('should not penalize standard fields', () => {
+    expect(namespaceRegulator(makeField({ name: 'AccountId', custom: false }))).toBeNull();
+  });
+});
+
+describe('labelDemotionRegulator', () => {
+  it('should penalize deprecated labels', () => {
+    const adj = labelDemotionRegulator(makeField({ label: 'Click Conversion (Deprecated)' }));
+    expect(adj?.delta).toBe(-80);
+  });
+
+  it('should penalize DO NOT USE labels', () => {
+    const adj = labelDemotionRegulator(makeField({ label: 'z[DO NOT USE] Old Field' }));
+    expect(adj?.delta).toBe(-80);
+  });
+
+  it('should penalize z-prefix convention', () => {
+    const adj = labelDemotionRegulator(makeField({ label: 'z[hidden]' }));
+    expect(adj?.delta).toBe(-80);
+  });
+
+  it('should penalize TECH prefix', () => {
+    const adj = labelDemotionRegulator(makeField({ name: 'TECHLastSync__c', label: 'TECHLastSync' }));
+    expect(adj?.delta).toBe(-30);
+  });
+
+  it('should return null for normal labels', () => {
+    expect(labelDemotionRegulator(makeField({ label: 'Annual Revenue' }))).toBeNull();
+  });
+});
+
+describe('qualityBoostRegulator', () => {
+  it('should boost fields with help text', () => {
+    const adj = qualityBoostRegulator(makeField({ helpText: 'Total revenue from all sources' }));
+    expect(adj?.delta).toBe(15);
+  });
+
+  it('should return null without help text', () => {
+    expect(qualityBoostRegulator(makeField())).toBeNull();
+  });
+
+  it('should return null for whitespace-only help text', () => {
+    expect(qualityBoostRegulator(makeField({ helpText: '   ' }))).toBeNull();
+  });
+});
+
+describe('typeRelevanceRegulator', () => {
+  it('should boost categorical fields', () => {
+    const adj = typeRelevanceRegulator(makeField({ computationType: 'categorical' }));
+    expect(adj?.delta).toBe(10);
+  });
+
+  it('should boost numeric fields', () => {
+    const adj = typeRelevanceRegulator(makeField({ computationType: 'numeric' }));
+    expect(adj?.delta).toBe(10);
+  });
+
+  it('should boost temporal fields less', () => {
+    const adj = typeRelevanceRegulator(makeField({ computationType: 'temporal' }));
+    expect(adj?.delta).toBe(5);
+  });
+
+  it('should return null for text fields', () => {
+    expect(typeRelevanceRegulator(makeField({ computationType: 'text' }))).toBeNull();
+  });
+});
+
+describe('autoPopulatedRegulator', () => {
+  it('should penalize PhotoUrl', () => {
+    const adj = autoPopulatedRegulator(makeField({ name: 'PhotoUrl' }));
+    expect(adj?.delta).toBe(-50);
+  });
+
+  it('should penalize Record_ID fields', () => {
+    const adj = autoPopulatedRegulator(makeField({ name: 'Record_ID__c' }));
+    expect(adj?.delta).toBe(-50);
+  });
+
+  it('should return null for normal fields', () => {
+    expect(autoPopulatedRegulator(makeField({ name: 'Revenue__c' }))).toBeNull();
+  });
+});
+
+describe('scoreField', () => {
+  it('should combine all regulator adjustments', () => {
+    const field = makeField({
+      populationPct: 100,
+      computationType: 'numeric',
+      helpText: 'Important metric',
+    });
+    const result = scoreField(field);
+    // population(100) + quality(15) + type(10) = 125
+    expect(result.score).toBe(125);
+    expect(result.adjustments.length).toBe(3);
+  });
+
+  it('should produce negative score for junk fields', () => {
+    const field = makeField({
+      name: 'adroll__Click_Conversion__c',
+      label: 'Click Conversion (Deprecated)',
+      populationPct: 100,
+    });
+    const result = scoreField(field);
+    // population(100) + namespace(-20) + deprecated(-80) = 0
+    expect(result.score).toBeLessThanOrEqual(0);
+  });
+});
+
+describe('regulateFields', () => {
+  it('should sort by score descending', () => {
+    const fields = [
+      makeField({ name: 'Low', populationPct: 10 }),
+      makeField({ name: 'High', populationPct: 90, computationType: 'numeric' }),
+      makeField({ name: 'Mid', populationPct: 50 }),
+    ];
+    const result = regulateFields(fields, 40);
+    expect(result[0].field.name).toBe('High');
+    expect(result[result.length - 1].field.name).toBe('Low');
+  });
+
+  it('should respect maxPromoted cap', () => {
+    const fields = Array.from({ length: 50 }, (_, i) =>
+      makeField({ name: `Field_${i}__c`, populationPct: 100 - i }),
+    );
+    const result = regulateFields(fields, 10);
+    const promoted = result.filter(r => r.promoted);
+    expect(promoted.length).toBeLessThanOrEqual(10);
+  });
+
+  it('should not promote fields with score <= 0', () => {
+    const fields = [
+      makeField({ name: 'adroll__Junk__c', label: 'Junk (Deprecated)', populationPct: 100 }),
+      makeField({ name: 'Good__c', populationPct: 80 }),
+    ];
+    const result = regulateFields(fields, 40);
+    const promoted = result.filter(r => r.promoted);
+    expect(promoted.every(p => p.score > 0)).toBe(true);
+    expect(promoted.some(p => p.field.name === 'Good__c')).toBe(true);
+  });
+});

--- a/src/__tests__/field-type-map.test.ts
+++ b/src/__tests__/field-type-map.test.ts
@@ -96,8 +96,13 @@ describe('field-type-map', () => {
       expect(info.validOperations).toEqual([]);
     });
 
-    it('should treat unknown types as text', () => {
+    it('should treat encryptedstring as binary', () => {
       const info = getComputationType('encryptedstring');
+      expect(info.computationType).toBe('binary');
+    });
+
+    it('should treat unknown types as text', () => {
+      const info = getComputationType('totallyFakeType');
       expect(info.computationType).toBe('text');
       expect(info.soqlNotes).toContain('Unknown SF field type');
     });

--- a/src/__tests__/rate-limited-executor.test.ts
+++ b/src/__tests__/rate-limited-executor.test.ts
@@ -1,0 +1,90 @@
+// Mock the backoff constants to avoid real delays in tests
+jest.mock('../utils/discovery-constants.js', () => ({
+  BACKOFF: {
+    initialDelayMs: 1,
+    multiplier: 1,
+    maxDelayMs: 5,
+    maxRetries: 2,
+    jitter: 0,
+  },
+}));
+
+import { withRetry, parallelLimit } from '../utils/rate-limited-executor.js';
+
+describe('withRetry', () => {
+  it('should return result on first success', async () => {
+    const result = await withRetry(() => Promise.resolve(42), 'test');
+    expect(result).toBe(42);
+  });
+
+  it('should retry on rate limit error', async () => {
+    let attempts = 0;
+    const fn = () => {
+      attempts++;
+      if (attempts < 2) {
+        const err: any = new Error('rate limited');
+        err.statusCode = 429;
+        return Promise.reject(err);
+      }
+      return Promise.resolve('ok');
+    };
+    const result = await withRetry(fn, 'test');
+    expect(result).toBe('ok');
+    expect(attempts).toBe(2);
+  });
+
+  it('should throw non-rate-limit errors immediately', async () => {
+    const fn = () => Promise.reject(new Error('bad query'));
+    await expect(withRetry(fn, 'test')).rejects.toThrow('bad query');
+  });
+
+  it('should throw after exhausting retries', async () => {
+    let attempts = 0;
+    const fn = () => {
+      attempts++;
+      const err: any = new Error('rate limited');
+      err.statusCode = 429;
+      return Promise.reject(err);
+    };
+    await expect(withRetry(fn, 'test')).rejects.toThrow();
+    expect(attempts).toBe(3); // initial + 2 retries
+  });
+});
+
+describe('parallelLimit', () => {
+  it('should execute all tasks', async () => {
+    const tasks = [1, 2, 3].map(n => () => Promise.resolve(n));
+    const results = await parallelLimit(tasks, 2);
+    expect(results).toEqual([1, 2, 3]);
+  });
+
+  it('should respect concurrency limit', async () => {
+    let maxConcurrent = 0;
+    let current = 0;
+
+    const tasks = Array.from({ length: 10 }, () => async () => {
+      current++;
+      maxConcurrent = Math.max(maxConcurrent, current);
+      await new Promise(r => setTimeout(r, 10));
+      current--;
+      return true;
+    });
+
+    await parallelLimit(tasks, 3);
+    expect(maxConcurrent).toBeLessThanOrEqual(3);
+  });
+
+  it('should handle empty task list', async () => {
+    const results = await parallelLimit([], 5);
+    expect(results).toEqual([]);
+  });
+
+  it('should preserve order', async () => {
+    const tasks = [30, 10, 20].map(delay => async () => {
+      await new Promise(r => setTimeout(r, delay));
+      return delay;
+    });
+    const results = await parallelLimit(tasks, 3);
+    expect(results).toEqual([30, 10, 20]);
+  });
+});

--- a/src/client/field-discovery.ts
+++ b/src/client/field-discovery.ts
@@ -1,0 +1,256 @@
+/**
+ * ADR-300 Field Discovery Module
+ *
+ * Runs at server startup (async, non-blocking) to discover, score, and
+ * regulate fields on core Salesforce objects. Results are cached for the
+ * session lifetime and exposed as MCP resources.
+ *
+ * The pipeline: describe → type-classify → population-score → regulate → cache
+ */
+
+import { SalesforceClient } from './salesforce-client.js';
+import { getComputationType, isScorable } from '../utils/field-type-map.js';
+import { FieldCandidate, ScoredField, regulateFields, DEFAULT_REGULATORS, Regulator } from '../utils/field-regulator.js';
+import { withRetry, parallelLimit } from '../utils/rate-limited-executor.js';
+import {
+  CORE_OBJECTS, DISCOVERY_CONCURRENCY, SCORING_BATCH_SIZE,
+  MAX_PROMOTED_PER_OBJECT, MAX_PROMOTED_TOTAL, WELL_KNOWN_PATTERNS,
+} from '../utils/discovery-constants.js';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface ObjectCatalog {
+  objectName: string;
+  /** All scored fields, sorted by score descending. */
+  fields: ScoredField[];
+  /** Just the promoted fields (convenience accessor). */
+  promoted: ScoredField[];
+  /** Well-known field resolutions for this object. */
+  wellKnown: Map<string, string>;
+  /** Discovery timing. */
+  describeMs: number;
+  scoringMs: number;
+  totalFields: number;
+  totalRecords: number;
+}
+
+export interface DiscoveryStats {
+  objectsDiscovered: number;
+  totalFieldsSeen: number;
+  totalPromoted: number;
+  totalMs: number;
+  ready: boolean;
+  errors: string[];
+}
+
+// ── FieldDiscovery Class ─────────────────────────────────────────────
+
+export class FieldDiscovery {
+  private catalogs = new Map<string, ObjectCatalog>();
+  private client: SalesforceClient;
+  private regulators: Regulator[];
+  private startupPromise: Promise<void> | null = null;
+  private errors: string[] = [];
+  private totalMs = 0;
+  private _ready = false;
+
+  constructor(client: SalesforceClient, regulators?: Regulator[]) {
+    this.client = client;
+    this.regulators = regulators ?? DEFAULT_REGULATORS;
+  }
+
+  /** Whether startup discovery has completed. */
+  get ready(): boolean { return this._ready; }
+
+  /** Kick off async discovery. Non-blocking, fire-and-forget safe. */
+  startAsync(): void {
+    if (this.startupPromise) return;
+    this.startupPromise = this.discoverCoreObjects();
+    this.startupPromise.catch((err) => {
+      console.error(`Field discovery failed: ${err.message}`);
+    });
+  }
+
+  /** Get the catalog for an object (returns undefined if not yet discovered). */
+  getCatalog(objectName: string): ObjectCatalog | undefined {
+    return this.catalogs.get(objectName);
+  }
+
+  /** Resolve a well-known semantic field name to its actual API name on this org. */
+  resolveWellKnown(objectName: string, semantic: string): string | undefined {
+    return this.catalogs.get(objectName)?.wellKnown.get(semantic);
+  }
+
+  /** Get discovery stats for the inspection surface. */
+  getStats(): DiscoveryStats {
+    let totalFieldsSeen = 0;
+    let totalPromoted = 0;
+    for (const catalog of this.catalogs.values()) {
+      totalFieldsSeen += catalog.totalFields;
+      totalPromoted += catalog.promoted.length;
+    }
+    return {
+      objectsDiscovered: this.catalogs.size,
+      totalFieldsSeen,
+      totalPromoted,
+      totalMs: this.totalMs,
+      ready: this._ready,
+      errors: [...this.errors],
+    };
+  }
+
+  /** Discover an object on-demand (if not already cached). */
+  async discoverObject(objectName: string): Promise<ObjectCatalog | null> {
+    if (this.catalogs.has(objectName)) return this.catalogs.get(objectName)!;
+    try {
+      const catalog = await this.probeAndRegulate(objectName);
+      this.catalogs.set(objectName, catalog);
+      this.enforceGlobalBudget();
+      return catalog;
+    } catch (err: any) {
+      this.errors.push(`${objectName}: ${err.message}`);
+      return null;
+    }
+  }
+
+  // ── Private ──────────────────────────────────────────────────────
+
+  private async discoverCoreObjects(): Promise<void> {
+    const start = Date.now();
+
+    const tasks = CORE_OBJECTS.map((obj) => async () => {
+      try {
+        const catalog = await this.probeAndRegulate(obj);
+        this.catalogs.set(obj, catalog);
+      } catch (err: any) {
+        this.errors.push(`${obj}: ${err.message}`);
+        console.error(`  Discovery failed for ${obj}: ${err.message}`);
+      }
+    });
+
+    await parallelLimit(tasks, DISCOVERY_CONCURRENCY);
+    this.enforceGlobalBudget();
+    this.totalMs = Date.now() - start;
+    this._ready = true;
+
+    const stats = this.getStats();
+    console.error(
+      `Field discovery complete: ${stats.objectsDiscovered} objects, ` +
+      `${stats.totalPromoted} promoted fields, ${stats.totalMs}ms` +
+      (stats.errors.length > 0 ? ` (${stats.errors.length} errors)` : ''),
+    );
+  }
+
+  private async probeAndRegulate(objectName: string): Promise<ObjectCatalog> {
+    // 1. Describe
+    const describeStart = Date.now();
+    const meta = await this.describeObject(objectName);
+    const describeMs = Date.now() - describeStart;
+
+    // 2. Build candidates with type classification
+    const candidates: FieldCandidate[] = meta.fields.map((f: any) => ({
+      name: f.name,
+      label: f.label,
+      type: f.type,
+      custom: f.custom,
+      helpText: f.inlineHelpText || null,
+      nillable: f.nillable,
+      computationType: getComputationType(f.type).computationType,
+    }));
+
+    // 3. Population scoring
+    const scoringStart = Date.now();
+    const scorable = candidates.filter(f => f.nillable && isScorable(f.type));
+    let totalRecords = 0;
+
+    try {
+      const countResult = await this.queryObject(objectName, 'SELECT COUNT() FROM ' + objectName);
+      totalRecords = countResult.totalSize ?? 0;
+    } catch (err: any) {
+      this.errors.push(`${objectName} COUNT: ${err.message}`);
+    }
+
+    if (totalRecords > 0) {
+      const scoringTasks = scorable.map((field) => async () => {
+        try {
+          const result = await withRetry(
+            () => this.queryObject(objectName, `SELECT COUNT(Id) cnt FROM ${objectName} WHERE ${field.name} != null`),
+            `${objectName}.${field.name}`,
+          );
+          const count = (result.records?.[0] as any)?.cnt ?? 0;
+          field.populationPct = Math.round((count / totalRecords) * 100);
+        } catch {
+          // Non-fatal: field just won't have population data
+        }
+      });
+      await parallelLimit(scoringTasks, SCORING_BATCH_SIZE);
+    }
+    const scoringMs = Date.now() - scoringStart;
+
+    // 4. Regulate and rank
+    const scored = regulateFields(candidates, MAX_PROMOTED_PER_OBJECT, this.regulators);
+
+    // 5. Well-known field resolution
+    const wellKnown = new Map<string, string>();
+    for (const pattern of WELL_KNOWN_PATTERNS) {
+      const match = candidates.find(
+        f => pattern.labelPattern.test(f.label) && f.type === pattern.type,
+      );
+      if (match) {
+        wellKnown.set(pattern.semantic, match.name);
+      }
+    }
+
+    return {
+      objectName,
+      fields: scored,
+      promoted: scored.filter(s => s.promoted),
+      wellKnown,
+      describeMs,
+      scoringMs,
+      totalFields: candidates.length,
+      totalRecords,
+    };
+  }
+
+  /** Enforce global budget — demote lowest-scoring promoted fields across objects. */
+  private enforceGlobalBudget(): void {
+    let totalPromoted = 0;
+    for (const catalog of this.catalogs.values()) {
+      totalPromoted += catalog.promoted.length;
+    }
+
+    if (totalPromoted <= MAX_PROMOTED_TOTAL) return;
+
+    // Collect all promoted fields with their object context
+    const allPromoted: Array<{ field: ScoredField; catalog: ObjectCatalog }> = [];
+    for (const catalog of this.catalogs.values()) {
+      for (const sf of catalog.promoted) {
+        allPromoted.push({ field: sf, catalog });
+      }
+    }
+
+    // Sort by score ascending — lowest scores get demoted first
+    allPromoted.sort((a, b) => a.field.score - b.field.score);
+
+    const toRemove = totalPromoted - MAX_PROMOTED_TOTAL;
+    for (let i = 0; i < toRemove; i++) {
+      allPromoted[i].field.promoted = false;
+    }
+
+    // Rebuild promoted arrays
+    for (const catalog of this.catalogs.values()) {
+      catalog.promoted = catalog.fields.filter(s => s.promoted);
+    }
+  }
+
+  private async describeObject(objectName: string): Promise<any> {
+    await this.client.ensureInitialized();
+    return this.client.getConnection().describe(objectName);
+  }
+
+  private async queryObject(_objectName: string, soql: string): Promise<any> {
+    await this.client.ensureInitialized();
+    return this.client.getConnection().query(soql);
+  }
+}

--- a/src/client/salesforce-client.ts
+++ b/src/client/salesforce-client.ts
@@ -1,6 +1,7 @@
 import jsforce from 'jsforce';
 import { PaginationParams, SimplifiedObject, SimplifiedUserInfo, PaginatedSimplifiedObject } from '../types/index.js';
 import { paginateResults, simplifyObjectMetadata, simplifyUserInfo, addPaginationToQuery, validateSalesforceId } from '../utils/index.js';
+import type { FieldDiscovery } from './field-discovery.js';
 
 export class SalesforceClient {
   private SF_CLIENT_ID: string;
@@ -43,6 +44,11 @@ export class SalesforceClient {
         console.error('Warmup auth failed, will retry on first tool call:', err.message);
       });
     }
+  }
+
+  /** Get the underlying jsforce Connection (must be initialized first). */
+  getConnection(): jsforce.Connection {
+    return this.conn;
   }
 
   /** Ensure authenticated before making API calls. Safe to call multiple times. */
@@ -220,8 +226,11 @@ export class SalesforceClient {
    *
    * Accepts either a ContentVersionId or ContentDocumentId.
    * If a ContentDocumentId is given, resolves the latest published version first.
+   *
+   * When fieldDiscovery is provided, resolves the "latest version" boolean field
+   * dynamically (ADR-300). Falls back to CreatedDate ordering if not available.
    */
-  async downloadFile(id: string): Promise<{
+  async downloadFile(id: string, fieldDiscovery?: FieldDiscovery): Promise<{
     buffer: Buffer;
     filename: string;
     mimeType: string;
@@ -242,11 +251,15 @@ export class SalesforceClient {
     // If it looks like a ContentDocumentId, resolve the latest version
     const prefix = id.substring(0, 3);
     if (prefix === '069') {
-      // Use CreatedDate ordering instead of a "latest version" boolean field,
-      // which varies across orgs (IsLatestVersion vs IsLatest). See ADR-300.
+      // ADR-300: resolve the "latest version" boolean field dynamically.
+      // Falls back to CreatedDate ordering if discovery isn't available.
+      const latestField = fieldDiscovery?.resolveWellKnown('ContentVersion', 'isLatestVersion');
+      const latestFilter = latestField
+        ? `AND ${latestField} = true`
+        : 'ORDER BY CreatedDate DESC';
       const result = await this.conn.query(
         `SELECT Id, Title, FileExtension, ContentSize, FileType, ContentDocumentId ` +
-        `FROM ContentVersion WHERE ContentDocumentId = '${id}' ORDER BY CreatedDate DESC LIMIT 1`
+        `FROM ContentVersion WHERE ContentDocumentId = '${id}' ${latestFilter} LIMIT 1`
       );
       if (!result.records || result.records.length === 0) {
         throw new Error(`No ContentVersion found for ContentDocumentId: ${id}`);

--- a/src/handlers/file-handlers.ts
+++ b/src/handlers/file-handlers.ts
@@ -1,5 +1,6 @@
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { SalesforceClient } from '../client/salesforce-client.js';
+import type { FieldDiscovery } from '../client/field-discovery.js';
 import { saveToWorkspace, formatFileOutput } from '../utils/file-output.js';
 import { sanitizeFilename } from '../utils/workspace.js';
 import { getNextSteps } from '../utils/next-steps.js';
@@ -12,7 +13,7 @@ function isDownloadFileParams(obj: any): obj is DownloadFileParams {
   return typeof obj === 'object' && obj !== null && typeof obj.contentId === 'string';
 }
 
-export async function handleDownloadFile(client: SalesforceClient, args: any) {
+export async function handleDownloadFile(client: SalesforceClient, args: any, fieldDiscovery?: FieldDiscovery) {
   if (!isDownloadFileParams(args)) {
     throw new McpError(
       ErrorCode.InvalidParams,
@@ -28,7 +29,7 @@ export async function handleDownloadFile(client: SalesforceClient, args: any) {
     );
   }
 
-  const fileInfo = await client.downloadFile(args.contentId);
+  const fileInfo = await client.downloadFile(args.contentId, fieldDiscovery);
   const safeFilename = sanitizeFilename(fileInfo.filename);
   const result = await saveToWorkspace(safeFilename, fileInfo.buffer, fileInfo.mimeType);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,12 +32,14 @@ import { handleDownloadFile } from './handlers/file-handlers.js';
 import { toolSchemas } from './schemas/tool-schemas.js';
 import { SessionCache } from './utils/session-cache.js';
 import { CacheMiddleware } from './utils/cache-middleware.js';
+import { FieldDiscovery } from './client/field-discovery.js';
 
 class SalesforceServer {
   private server: Server;
   private sfClient: SalesforceClient;
   private cache: SessionCache;
   private cacheMiddleware: CacheMiddleware;
+  private fieldDiscovery: FieldDiscovery;
 
   constructor() {
     console.error('Loading tool schemas...');
@@ -65,6 +67,7 @@ class SalesforceServer {
     this.sfClient.warmup();
     this.cache = new SessionCache();
     this.cacheMiddleware = new CacheMiddleware(this.cache);
+    this.fieldDiscovery = new FieldDiscovery(this.sfClient);
 
     this.setupHandlers();
     
@@ -89,16 +92,90 @@ class SalesforceServer {
       })),
     }));
 
-    this.server.setRequestHandler(ListResourcesRequestSchema, async () => ({
-      resources: [], // No resources provided by this server
-    }));
+    this.server.setRequestHandler(ListResourcesRequestSchema, async () => {
+      const resources: Array<{ uri: string; name: string; description: string; mimeType: string }> = [];
+
+      // Add field catalog resources for discovered objects
+      if (this.fieldDiscovery.ready) {
+        const stats = this.fieldDiscovery.getStats();
+        resources.push({
+          uri: 'salesforce://field-catalog/_stats',
+          name: 'Field Discovery Stats',
+          description: `Discovery status: ${stats.objectsDiscovered} objects, ${stats.totalPromoted} promoted fields`,
+          mimeType: 'application/json',
+        });
+
+        for (const objectName of ['Account', 'Opportunity', 'Contact', 'Lead', 'Contract', 'ContentVersion']) {
+          const catalog = this.fieldDiscovery.getCatalog(objectName);
+          if (catalog) {
+            resources.push({
+              uri: `salesforce://field-catalog/${objectName}`,
+              name: `${objectName} Field Catalog`,
+              description: `${catalog.promoted.length} promoted fields out of ${catalog.totalFields}`,
+              mimeType: 'application/json',
+            });
+          }
+        }
+      }
+
+      return { resources };
+    });
 
     this.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({
-      resourceTemplates: [], // No resource templates provided by this server
+      resourceTemplates: [{
+        uriTemplate: 'salesforce://field-catalog/{objectName}',
+        name: 'Field Catalog',
+        description: 'Promoted fields for a Salesforce object, ranked by usage and quality',
+        mimeType: 'application/json',
+      }],
     }));
 
     this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
-      throw new McpError(ErrorCode.InvalidRequest, `No resources available: ${request.params.uri}`);
+      const uri = request.params.uri;
+
+      // salesforce://field-catalog/_stats
+      if (uri === 'salesforce://field-catalog/_stats') {
+        const stats = this.fieldDiscovery.getStats();
+        return {
+          contents: [{ uri, mimeType: 'application/json', text: JSON.stringify(stats, null, 2) }],
+        };
+      }
+
+      // salesforce://field-catalog/{objectName}
+      const catalogMatch = uri.match(/^salesforce:\/\/field-catalog\/(\w+)$/);
+      if (catalogMatch) {
+        const objectName = catalogMatch[1];
+        // Try cached, or discover on-demand
+        let catalog = this.fieldDiscovery.getCatalog(objectName);
+        if (!catalog) {
+          catalog = await this.fieldDiscovery.discoverObject(objectName) ?? undefined;
+        }
+        if (!catalog) {
+          throw new McpError(ErrorCode.InvalidRequest, `Could not discover fields for: ${objectName}`);
+        }
+
+        const payload = {
+          objectName: catalog.objectName,
+          totalFields: catalog.totalFields,
+          totalRecords: catalog.totalRecords,
+          promoted: catalog.promoted.map(s => ({
+            name: s.field.name,
+            label: s.field.label,
+            type: s.field.type,
+            computationType: s.field.computationType,
+            custom: s.field.custom,
+            score: s.score,
+            populationPct: s.field.populationPct,
+            adjustments: s.adjustments.map(a => `${a.delta > 0 ? '+' : ''}${a.delta} ${a.reason}`),
+          })),
+          wellKnown: Object.fromEntries(catalog.wellKnown),
+        };
+        return {
+          contents: [{ uri, mimeType: 'application/json', text: JSON.stringify(payload, null, 2) }],
+        };
+      }
+
+      throw new McpError(ErrorCode.InvalidRequest, `Unknown resource: ${uri}`);
     });
 
     // Set up tool handlers
@@ -135,7 +212,7 @@ class SalesforceServer {
             return await handleGetUserInfo(this.sfClient);
 
           case 'download_file':
-            return await handleDownloadFile(this.sfClient, request.params.arguments);
+            return await handleDownloadFile(this.sfClient, request.params.arguments, this.fieldDiscovery);
 
           case 'list_objects':
             return await handleListObjects(this.sfClient, request.params.arguments);
@@ -190,9 +267,15 @@ class SalesforceServer {
 
     // Kick off Salesforce auth in the background — errors are logged
     // but don't crash the server; they'll surface on the first tool call.
-    this.sfClient.initialize().catch((err) => {
-      console.error(`Salesforce auth failed (will retry on first tool call): ${err.message}`);
-    });
+    this.sfClient.initialize()
+      .then(() => {
+        // After auth succeeds, start field discovery (ADR-300).
+        // Non-blocking — tools work immediately, discovery enriches over time.
+        this.fieldDiscovery.startAsync();
+      })
+      .catch((err) => {
+        console.error(`Salesforce auth failed (will retry on first tool call): ${err.message}`);
+      });
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { toolSchemas } from './schemas/tool-schemas.js';
 import { SessionCache } from './utils/session-cache.js';
 import { CacheMiddleware } from './utils/cache-middleware.js';
 import { FieldDiscovery } from './client/field-discovery.js';
+import { CORE_OBJECTS } from './utils/discovery-constants.js';
 
 class SalesforceServer {
   private server: Server;
@@ -105,7 +106,7 @@ class SalesforceServer {
           mimeType: 'application/json',
         });
 
-        for (const objectName of ['Account', 'Opportunity', 'Contact', 'Lead', 'Contract', 'ContentVersion']) {
+        for (const objectName of CORE_OBJECTS) {
           const catalog = this.fieldDiscovery.getCatalog(objectName);
           if (catalog) {
             resources.push({

--- a/src/utils/discovery-constants.ts
+++ b/src/utils/discovery-constants.ts
@@ -1,0 +1,49 @@
+/**
+ * ADR-300 Field Discovery — Tunable Constants
+ *
+ * Centralized parameters for field discovery. Adjust these to control
+ * startup cost, API pressure, and catalog size.
+ */
+
+/** Objects to discover at startup. Others discovered on-demand via describe_object. */
+export const CORE_OBJECTS = [
+  'Account', 'Opportunity', 'Contact', 'Lead', 'Contract', 'ContentVersion',
+];
+
+/** Max concurrent Salesforce API calls during discovery (describes + scoring). */
+export const DISCOVERY_CONCURRENCY = 3;
+
+/** Max concurrent population scoring queries per object. */
+export const SCORING_BATCH_SIZE = 5;
+
+/** Max promoted fields per object (hard cap above the tail-curve knee). */
+export const MAX_PROMOTED_PER_OBJECT = 40;
+
+/** Max total promoted fields across all objects (global context budget). */
+export const MAX_PROMOTED_TOTAL = 200;
+
+/** Backoff configuration for 429 / rate limit responses. */
+export const BACKOFF = {
+  /** Initial delay in ms after first 429. */
+  initialDelayMs: 1000,
+  /** Multiplier per retry (exponential). */
+  multiplier: 2,
+  /** Max delay cap in ms. */
+  maxDelayMs: 30_000,
+  /** Max retries before giving up on a single query. */
+  maxRetries: 3,
+  /** Jitter range (0-1). 0.5 = ±50% of calculated delay. */
+  jitter: 0.5,
+};
+
+/**
+ * Well-known field patterns — fields with known semantic meaning
+ * but variable API names across orgs. Resolved by label + type matching.
+ */
+export const WELL_KNOWN_PATTERNS: Array<{
+  semantic: string;
+  labelPattern: RegExp;
+  type: string;
+}> = [
+  { semantic: 'isLatestVersion', labelPattern: /latest/i, type: 'boolean' },
+];

--- a/src/utils/field-regulator.ts
+++ b/src/utils/field-regulator.ts
@@ -1,0 +1,179 @@
+/**
+ * ADR-300 Field Regulator — composable scoring pipeline for field promotion.
+ *
+ * Each regulator is a pure function that adjusts a field's score based on
+ * a single signal (population, namespace, label, type, etc.). Regulators
+ * stack — all run on every field, order doesn't matter. The audit trail
+ * of adjustments makes promotion decisions transparent and debuggable.
+ */
+
+import { ComputationType } from './field-type-map.js';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface FieldCandidate {
+  name: string;
+  label: string;
+  type: string;
+  custom: boolean;
+  helpText: string | null;
+  nillable: boolean;
+  computationType: ComputationType;
+  /** Population percentage (0-100), undefined if not scored. */
+  populationPct?: number;
+}
+
+export interface ScoreAdjustment {
+  regulator: string;
+  /** Positive = boost, negative = penalty. */
+  delta: number;
+  reason: string;
+}
+
+export interface ScoredField {
+  field: FieldCandidate;
+  score: number;
+  adjustments: ScoreAdjustment[];
+  promoted: boolean;
+}
+
+/** A regulator: field in, adjustment out (or null to skip). */
+export type Regulator = (field: FieldCandidate) => ScoreAdjustment | null;
+
+// ── Built-in Regulators ──────────────────────────────────────────────
+
+/** Base population score from `WHERE field != null` density. */
+export const populationRegulator: Regulator = (field) => {
+  if (field.populationPct === undefined) return null;
+  return {
+    regulator: 'population',
+    delta: field.populationPct,
+    reason: `${field.populationPct}% populated`,
+  };
+};
+
+/** Managed package namespace penalty (prefix__FieldName__c). */
+export const namespaceRegulator: Regulator = (field) => {
+  if (!field.custom) return null;
+  const match = field.name.match(/^([a-zA-Z0-9]+)__\w+__c$/);
+  if (!match) return null;
+
+  return {
+    regulator: 'namespace',
+    delta: -20,
+    reason: `managed package (${match[1]}__)`,
+  };
+};
+
+/** Label-based demotion for deprecated/abandoned fields. */
+export const labelDemotionRegulator: Regulator = (field) => {
+  const label = field.label.toLowerCase();
+  const name = field.name.toLowerCase();
+
+  if (label.includes('deprecated') || label.includes('do not use')) {
+    return { regulator: 'label-demotion', delta: -80, reason: `deprecated: "${field.label}"` };
+  }
+  if (label.startsWith('z[') || label.startsWith('z ')) {
+    return { regulator: 'label-demotion', delta: -80, reason: `z-prefix (hidden): "${field.label}"` };
+  }
+  if (name.startsWith('tech') || label.startsWith('TECH')) {
+    return { regulator: 'label-demotion', delta: -30, reason: `TECH prefix (automation): "${field.label}"` };
+  }
+  return null;
+};
+
+/** Boost for fields with help text — someone invested in documenting them. */
+export const qualityBoostRegulator: Regulator = (field) => {
+  if (field.helpText && field.helpText.trim().length > 0) {
+    return { regulator: 'quality-boost', delta: 15, reason: 'has help text' };
+  }
+  return null;
+};
+
+/** Categorical/numeric fields are more analytically useful. */
+export const typeRelevanceRegulator: Regulator = (field) => {
+  switch (field.computationType) {
+    case 'categorical':
+      return { regulator: 'type-relevance', delta: 10, reason: 'categorical (groupable)' };
+    case 'numeric':
+      return { regulator: 'type-relevance', delta: 10, reason: 'numeric (aggregatable)' };
+    case 'temporal':
+      return { regulator: 'type-relevance', delta: 5, reason: 'temporal (rangeable)' };
+    case 'flag':
+      return { regulator: 'type-relevance', delta: 5, reason: 'boolean (filterable)' };
+    default:
+      return null;
+  }
+};
+
+/** Penalty for system/formula fields that auto-populate on every record. */
+export const autoPopulatedRegulator: Regulator = (field) => {
+  const patterns = [
+    /^PhotoUrl$/i, /^Record_ID/i, /ID_18_Character/i,
+    /^Jigsaw/i, /SystemModstamp/i, /^Is(Deleted|Archived)/i,
+  ];
+  if (patterns.some(p => p.test(field.name))) {
+    return { regulator: 'auto-populated', delta: -50, reason: `system auto-populated: ${field.name}` };
+  }
+  return null;
+};
+
+// ── Pipeline ─────────────────────────────────────────────────────────
+
+export const DEFAULT_REGULATORS: Regulator[] = [
+  populationRegulator,
+  namespaceRegulator,
+  labelDemotionRegulator,
+  qualityBoostRegulator,
+  typeRelevanceRegulator,
+  autoPopulatedRegulator,
+];
+
+/** Score a single field through all regulators. */
+export function scoreField(
+  field: FieldCandidate,
+  regulators: Regulator[] = DEFAULT_REGULATORS,
+): ScoredField {
+  const adjustments: ScoreAdjustment[] = [];
+  let score = 0;
+
+  for (const reg of regulators) {
+    const adj = reg(field);
+    if (adj) {
+      adjustments.push(adj);
+      score += adj.delta;
+    }
+  }
+
+  return { field, score, adjustments, promoted: false };
+}
+
+/** Score all fields, rank, and apply promotion cutoff. */
+export function regulateFields(
+  fields: FieldCandidate[],
+  maxPromoted: number,
+  regulators: Regulator[] = DEFAULT_REGULATORS,
+): ScoredField[] {
+  const scored = fields.map(f => scoreField(f, regulators));
+  scored.sort((a, b) => b.score - a.score);
+
+  // Find natural break in scores (knee detection)
+  const positiveScores = scored.filter(s => s.score > 0);
+  let cutoffIndex = Math.min(maxPromoted, positiveScores.length);
+
+  for (let i = 4; i < Math.min(cutoffIndex, positiveScores.length - 1); i++) {
+    const relDrop = positiveScores[i].score > 0
+      ? (positiveScores[i].score - positiveScores[i + 1].score) / positiveScores[i].score
+      : 0;
+    if (relDrop > 0.5) {
+      cutoffIndex = i + 1;
+      break;
+    }
+  }
+
+  for (let i = 0; i < scored.length; i++) {
+    scored[i].promoted = i < cutoffIndex && scored[i].score > 0;
+  }
+
+  return scored;
+}

--- a/src/utils/field-type-map.ts
+++ b/src/utils/field-type-map.ts
@@ -159,6 +159,34 @@ const SF_TYPE_MAP: Record<string, FieldTypeInfo> = {
   },
 };
 
+/** Encrypted string — not queryable in WHERE */
+const ENCRYPTED_TYPE: FieldTypeInfo = {
+  computationType: 'binary',
+  validOperations: [],
+  soqlNotes: 'Encrypted; cannot filter or aggregate',
+};
+
+// Register encryptedstring
+SF_TYPE_MAP['encryptedstring'] = ENCRYPTED_TYPE;
+
+/**
+ * Determine whether a field type supports population scoring
+ * (i.e., can be used in `WHERE field != null` queries).
+ *
+ * This is stricter than general filterability — long text (textarea)
+ * is technically a text type but Salesforce disallows `!= null` on it.
+ */
+export function isScorable(sfFieldType: string): boolean {
+  const info = getComputationType(sfFieldType);
+  // These types cannot appear in WHERE clauses at all
+  if (info.computationType === 'compound' || info.computationType === 'binary') return false;
+  // Identifiers are always populated or meaningless to score
+  if (info.computationType === 'identifier') return false;
+  // Long text fields can't use != null in WHERE
+  if (sfFieldType.toLowerCase() === 'textarea') return false;
+  return true;
+}
+
 /** Default for unknown Salesforce field types */
 const UNKNOWN_TYPE_INFO: FieldTypeInfo = {
   computationType: 'text',

--- a/src/utils/rate-limited-executor.ts
+++ b/src/utils/rate-limited-executor.ts
@@ -1,0 +1,77 @@
+/**
+ * Rate-limited concurrent executor with exponential backoff.
+ *
+ * Prevents thundering herd on Salesforce API during field discovery.
+ * Respects a concurrency limit and backs off on 429 responses.
+ *
+ * See ADR-300 for design context.
+ */
+
+import { BACKOFF } from './discovery-constants.js';
+
+function isRateLimited(err: unknown): boolean {
+  const e = err as { statusCode?: number; errorCode?: string; message?: string };
+  if (e?.statusCode === 429) return true;
+  if (e?.errorCode === 'REQUEST_LIMIT_EXCEEDED') return true;
+  if (typeof e?.message === 'string' && e.message.includes('REQUEST_LIMIT_EXCEEDED')) return true;
+  return false;
+}
+
+function calculateDelay(attempt: number): number {
+  const base = BACKOFF.initialDelayMs * Math.pow(BACKOFF.multiplier, attempt);
+  const capped = Math.min(base, BACKOFF.maxDelayMs);
+  const jitterRange = capped * BACKOFF.jitter;
+  return capped + (Math.random() * 2 - 1) * jitterRange;
+}
+
+/**
+ * Execute a function with retry on Salesforce rate limiting (429).
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  label: string,
+): Promise<T> {
+  for (let attempt = 0; attempt <= BACKOFF.maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (isRateLimited(err) && attempt < BACKOFF.maxRetries) {
+        const delay = calculateDelay(attempt);
+        console.error(`  [429] ${label} — retrying in ${Math.round(delay)}ms (attempt ${attempt + 1}/${BACKOFF.maxRetries})`);
+        await new Promise(resolve => setTimeout(resolve, delay));
+        continue;
+      }
+      throw err;
+    }
+  }
+  // TypeScript: unreachable, but satisfies the compiler
+  throw new Error(`${label}: exhausted retries`);
+}
+
+/**
+ * Run async tasks with bounded concurrency.
+ *
+ * Unlike Promise.all which fires everything at once, this maintains
+ * at most `concurrency` in-flight tasks at any time.
+ */
+export async function parallelLimit<T>(
+  tasks: Array<() => Promise<T>>,
+  concurrency: number,
+): Promise<T[]> {
+  const results: T[] = new Array(tasks.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < tasks.length) {
+      const index = nextIndex++;
+      results[index] = await tasks[index]();
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, tasks.length) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+  return results;
+}


### PR DESCRIPTION
## Summary

- **Field discovery module** — async startup discovery of core Salesforce objects. Describes fields, scores population density, runs composable regulator pipeline, caches for session lifetime.
- **FieldRegulator** — 6 built-in regulators (population, namespace, label demotion, quality boost, type relevance, auto-populated detection). Transparent audit trails on every score.
- **MCP resources** — `salesforce://field-catalog/{objectName}` exposes promoted fields ranked by score. `salesforce://field-catalog/_stats` for discovery health.
- **Rate-limited executor** — bounded concurrency (3 describes, 5 scoring queries) with exponential backoff + jitter on 429s.
- **Well-known field resolution** — `downloadFile` resolves `IsLatest` dynamically by label+type matching instead of hardcoding field names that vary across orgs.
- **Global budget cap** — 200 total promoted fields across all objects prevents context explosion.
- **ADR-300 status → Accepted** with experimental validation results.

## Validated against live org

- 6 objects, 665 fields, 200 promoted, 6.4s discovery time, zero errors
- Correctly demotes: managed packages (adroll__), deprecated labels, auto-populated system fields (PhotoUrl), TECH prefix
- Correctly boosts: fields with help text, categorical/numeric types
- Well-known resolution: `ContentVersion.isLatestVersion → IsLatest`
- Full MathWorks customer deep-dive: account → opps → contracts → file downloads all working

## Test plan

- [x] 346 tests pass (35 new: regulator, executor, type-map)
- [x] `make check` clean (0 lint errors, build passes)
- [x] Live-tested discovery stats resource
- [x] Live-tested field catalog resource for ContentVersion
- [x] Live-tested download_file with discovery-resolved field name
- [x] End-to-end: MathWorks account → 3 PDFs downloaded via ContentDocumentLink