### PR TITLE
docs: add release runbook and mcpb CI workflow

### DIFF
--- a/.github/workflows/release-mcpb.yml
+++ b/.github/workflows/release-mcpb.yml
@@ -1,0 +1,46 @@
+name: Build .mcpb release artifact
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  build-mcpb:
+    name: Build .mcpb bundle
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # needed for gh release upload
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Install mcpb CLI
+        run: npm install -g @anthropic-ai/mcpb
+
+      - name: Build .mcpb
+        run: make mcpb
+
+      - name: Create GitHub Release (if not exists)
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          gh release view "$TAG" 2>/dev/null || gh release create "$TAG" --title "$TAG" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload .mcpb artifact to release
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          gh release upload "$TAG" salesforce-cloud-mcp.mcpb --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -79,13 +79,12 @@ mcpb: build     ## Build .mcpb desktop extension bundle
 	@echo ""
 	@echo "Built: salesforce-cloud-mcp.mcpb ($$(du -h salesforce-cloud-mcp.mcpb | cut -f1))"
 
-publish-all: mcpb  ## Build MCPB, publish to MCP Registry + GitHub Release (npm via trusted publisher)
+publish-all: mcpb  ## Build MCPB, publish to MCP Registry (npm + GitHub Release via CI)
 	@echo ""
 	@echo "Publishing v$(VERSION):"
-	@echo "  - npm: automatic via GitHub Actions trusted publisher (triggered by tag push)"
+	@echo "  - npm: automatic via CI (triggered by tag push)"
+	@echo "  - GitHub Release + .mcpb: automatic via CI (triggered by tag push)"
 	@echo "  - MCP Registry: manual (below)"
-	@echo "  - GitHub Release: manual (below)"
-	@echo "  - MCPB bundle: already built"
 	@echo ""
 	@read -p "Continue? [y/N] " confirm && [ "$$confirm" = "y" ] || (echo "Aborted." && exit 1)
 	@echo ""
@@ -94,12 +93,12 @@ publish-all: mcpb  ## Build MCPB, publish to MCP Registry + GitHub Release (npm 
 	mcp-publisher publish server.json
 	@echo ""
 	@echo "── GitHub Release ──"
-	@read -p "Release notes (one line, or empty for default): " notes; \
-	if [ -z "$$notes" ]; then notes="Release v$(VERSION)"; fi; \
-	gh release create "v$(VERSION)" --title "v$(VERSION)" --notes "$$notes" salesforce-cloud-mcp.mcpb
+	@echo "Uploading .mcpb to existing release (created by CI)..."
+	gh release upload "v$(VERSION)" salesforce-cloud-mcp.mcpb --clobber 2>/dev/null || \
+		(echo "Release v$(VERSION) not found — CI may not have run yet. Creating..."; \
+		gh release create "v$(VERSION)" --title "v$(VERSION)" --notes "Release v$(VERSION)" salesforce-cloud-mcp.mcpb)
 	@echo ""
-	@echo "v$(VERSION) published. npm publishes automatically from the v$(VERSION) tag."
-	@echo "MCPB bundle: salesforce-cloud-mcp.mcpb"
+	@echo "v$(VERSION) published."
 
 help:           ## Show this help
 	@grep -E '^[a-z_-]+:.*##' $(MAKEFILE_LIST) | awk -F ':.*## ' '{printf "  %-16s %s\n", $$1, $$2}'

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,135 @@
+# Release Runbook
+
+How to ship a new version of salesforce-cloud-mcp.
+
+## What Happens on Release
+
+A single `git tag` push triggers two CI workflows:
+
+| Workflow | File | What it does |
+|----------|------|-------------|
+| **Publish to npm** | `.github/workflows/npm-publish.yml` | Builds, publishes to npm with provenance |
+| **Build .mcpb** | `.github/workflows/release-mcpb.yml` | Builds .mcpb bundle, attaches to GitHub Release |
+
+Both npm and mcpb publishing start from the same `v*` tag.
+
+## Release Flow
+
+### 1. Ensure main is clean
+
+```bash
+git checkout main && git pull
+make check          # lint + test + build must pass
+```
+
+### 2. Bump version
+
+```bash
+# Pick one:
+make release-patch  # x.y.Z — bug fixes
+make release-minor  # x.Y.0 — new features
+make release-major  # X.0.0 — breaking changes
+```
+
+`make release-*` runs `check`, bumps `package.json`, syncs version to `server.json` + `manifest.json` + `mcpb/manifest.json`, commits, tags, and pushes.
+
+If `make check` fails, fix it first. Don't skip the check.
+
+### 3. Publish to MCP Registry (manual)
+
+The npm publish and .mcpb GitHub Release are automated by CI. The MCP Registry publish is manual:
+
+```bash
+make publish-all    # builds .mcpb locally, publishes to MCP Registry, creates GitHub Release
+```
+
+Or just the registry step:
+
+```bash
+mcp-publisher login github
+mcp-publisher publish server.json
+```
+
+### 4. Manual release (if make fails)
+
+If `make release-*` fails partway through, complete manually:
+
+```bash
+npm version minor --no-git-tag-version   # or patch/major
+make version-sync                         # sync to server.json + manifest.json + mcpb/manifest.json
+git add package.json package-lock.json server.json manifest.json mcpb/manifest.json
+git commit -m "chore: release vX.Y.Z"
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push && git push --tags
+```
+
+### 5. Verify CI
+
+```bash
+gh run list --limit 3   # should show npm-publish running
+gh run watch <run-id>   # watch it
+```
+
+### 6. Verify artifacts
+
+```bash
+# npm
+npm view @aaronsb/salesforce-cloud-mcp version
+
+# GitHub Release — should have salesforce-cloud-mcp.mcpb attached
+gh release view vX.Y.Z
+```
+
+## Pre-release Versions
+
+For alpha/beta/rc releases:
+
+```bash
+npm version preminor --preid alpha --no-git-tag-version
+# → x.y.0-alpha.0
+make version-sync
+# commit, tag, push as above
+```
+
+## Retagging
+
+If a tag was pushed before a fix was ready:
+
+```bash
+git tag -d vX.Y.Z                        # delete local tag
+git push origin :refs/tags/vX.Y.Z        # delete remote tag
+# fix the issue, commit, push
+git tag -a vX.Y.Z -m "vX.Y.Z"           # retag on fixed commit
+git push --tags                           # triggers CI again
+```
+
+## Local .mcpb Builds
+
+For testing or manual distribution without CI:
+
+```bash
+make mcpb              # builds bundle for current platform
+```
+
+Requires `mcpb` CLI installed (`npm install -g @anthropic-ai/mcpb`).
+
+## Version Files
+
+The version lives in four places, kept in sync by `make version-sync`:
+
+| File | Field | Purpose |
+|------|-------|---------|
+| `package.json` | `version` | Source of truth, npm |
+| `server.json` | `version` | MCP server metadata |
+| `manifest.json` | `version` | Desktop extension metadata |
+| `mcpb/manifest.json` | `version` | .mcpb bundle metadata |
+
+Never edit these manually — use `npm version` + `make version-sync`.
+
+## Publishing Channels
+
+| Channel | How | Automated? |
+|---------|-----|-----------|
+| **npm** | Tag push triggers `.github/workflows/npm-publish.yml` | Yes (CI) |
+| **.mcpb + GitHub Release** | Tag push triggers `.github/workflows/release-mcpb.yml` | Yes (CI) |
+| **MCP Registry** | `mcp-publisher publish server.json` | No (manual) |


### PR DESCRIPTION
## Summary
- Add `docs/release-runbook.md` mirroring the release pattern from google-workspace-mcp
- Add `.github/workflows/release-mcpb.yml` to build a single `.mcpb` bundle and attach it to a GitHub Release on `v*` tag push
- Runbook documents the full release flow: npm (CI), mcpb (CI), MCP Registry (manual)

## Test plan
- [ ] Verify `release-mcpb.yml` syntax is valid
- [ ] Verify runbook accurately reflects Makefile targets and CI workflows
- [ ] Next tag push should trigger both npm-publish and release-mcpb workflows