### PR TITLE
Stop the tool descriptions ordering a recon round-trip

### DIFF
--- a/src/__tests__/field-discovery.test.ts
+++ b/src/__tests__/field-discovery.test.ts
@@ -421,6 +421,42 @@ describe('FieldDiscovery', () => {
     });
   });
 
+  describe('whenSettled', () => {
+    it('resolves once startup discovery has finished', async () => {
+      const { client } = makeClient({
+        describes: Object.fromEntries(CORE_OBJECTS.map(o => [o, [field({ name: 'Name' })]])),
+        counts: Object.fromEntries(CORE_OBJECTS.map(o => [o, 1])),
+      });
+      const discovery = new FieldDiscovery(client);
+
+      discovery.startAsync();
+      await discovery.whenSettled();
+
+      expect(discovery.ready).toBe(true);
+    });
+
+    // Callers wait on this to react to discovery landing. Discovery already
+    // logs and records its own failures, so rejecting here would force every
+    // caller to handle an error that has already been dealt with.
+    it('resolves rather than rejecting when discovery blows up', async () => {
+      const { client } = makeClient();
+      const discovery = new FieldDiscovery(client);
+      jest.spyOn(discovery as any, 'discoverCoreObjects').mockRejectedValue(new Error('boom'));
+
+      discovery.startAsync();
+
+      await expect(discovery.whenSettled()).resolves.toBeUndefined();
+    });
+
+    it('resolves immediately when discovery was never started', async () => {
+      const { client } = makeClient();
+      const discovery = new FieldDiscovery(client);
+
+      await expect(discovery.whenSettled()).resolves.toBeUndefined();
+      expect(discovery.ready).toBe(false);
+    });
+  });
+
   describe('global promotion budget', () => {
     it('caps promoted fields at the per-object maximum', async () => {
       const many = Array.from({ length: MAX_PROMOTED_PER_OBJECT + 20 }, (_, i) =>

--- a/src/__tests__/field-discovery.test.ts
+++ b/src/__tests__/field-discovery.test.ts
@@ -430,8 +430,8 @@ describe('FieldDiscovery', () => {
       const discovery = new FieldDiscovery(client);
 
       discovery.startAsync();
-      await discovery.whenSettled();
 
+      await expect(discovery.whenSettled()).resolves.toBe(true);
       expect(discovery.ready).toBe(true);
     });
 
@@ -445,14 +445,16 @@ describe('FieldDiscovery', () => {
 
       discovery.startAsync();
 
-      await expect(discovery.whenSettled()).resolves.toBeUndefined();
+      await expect(discovery.whenSettled()).resolves.toBe(true);
     });
 
-    it('resolves immediately when discovery was never started', async () => {
+    // A bare resolve() here would be indistinguishable from "discovery
+    // finished", and a caller would act on a state change that never happened.
+    it('reports false when discovery was never started', async () => {
       const { client } = makeClient();
       const discovery = new FieldDiscovery(client);
 
-      await expect(discovery.whenSettled()).resolves.toBeUndefined();
+      await expect(discovery.whenSettled()).resolves.toBe(false);
       expect(discovery.ready).toBe(false);
     });
   });

--- a/src/__tests__/server-startup.test.ts
+++ b/src/__tests__/server-startup.test.ts
@@ -93,4 +93,64 @@ describe('SalesforceServer startup', () => {
 
     expect(startAsync).not.toHaveBeenCalled();
   });
+
+  // The resource list is built before discovery can have run, so every catalog
+  // in it is described as "in progress". Clients cache that listing at connect
+  // and have no reason to refetch — without a notification the labels stay
+  // wrong for the whole session while the resources themselves read fine.
+  describe('resource list notification', () => {
+    it('tells clients to refetch once discovery settles', async () => {
+      const server = new SalesforceServer();
+      jest.spyOn(server['fieldDiscovery'], 'startAsync').mockImplementation(() => {});
+      jest.spyOn(server['fieldDiscovery'], 'whenSettled').mockResolvedValue(undefined);
+      const notify = jest.spyOn(server['server'], 'sendResourceListChanged').mockResolvedValue(undefined);
+
+      await server.startBackgroundInit();
+
+      expect(notify).toHaveBeenCalledTimes(1);
+    });
+
+    it('waits for discovery rather than announcing immediately', async () => {
+      const server = new SalesforceServer();
+      let settle: () => void = () => {};
+      jest.spyOn(server['fieldDiscovery'], 'startAsync').mockImplementation(() => {});
+      jest.spyOn(server['fieldDiscovery'], 'whenSettled')
+        .mockReturnValue(new Promise<void>(res => { settle = res; }));
+      const notify = jest.spyOn(server['server'], 'sendResourceListChanged').mockResolvedValue(undefined);
+
+      const init = server.startBackgroundInit();
+      await new Promise(process.nextTick);
+      expect(notify).not.toHaveBeenCalled();
+
+      settle();
+      await init;
+      expect(notify).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not announce when auth failed and discovery never ran', async () => {
+      conn.login.mockRejectedValue(new Error('bad credentials'));
+      const server = new SalesforceServer();
+      const notify = jest.spyOn(server['server'], 'sendResourceListChanged').mockResolvedValue(undefined);
+
+      await server.startBackgroundInit();
+
+      expect(notify).not.toHaveBeenCalled();
+    });
+
+    it('survives a client that has gone away', async () => {
+      const server = new SalesforceServer();
+      jest.spyOn(server['fieldDiscovery'], 'startAsync').mockImplementation(() => {});
+      jest.spyOn(server['fieldDiscovery'], 'whenSettled').mockResolvedValue(undefined);
+      jest.spyOn(server['server'], 'sendResourceListChanged')
+        .mockRejectedValue(new Error('Not connected'));
+
+      await expect(server.startBackgroundInit()).resolves.toBeUndefined();
+    });
+
+    it('declares the listChanged capability so clients act on the notification', () => {
+      const server = new SalesforceServer();
+
+      expect(server['server']['_capabilities'].resources).toMatchObject({ listChanged: true });
+    });
+  });
 });

--- a/src/__tests__/server-startup.test.ts
+++ b/src/__tests__/server-startup.test.ts
@@ -102,7 +102,7 @@ describe('SalesforceServer startup', () => {
     it('tells clients to refetch once discovery settles', async () => {
       const server = new SalesforceServer();
       jest.spyOn(server['fieldDiscovery'], 'startAsync').mockImplementation(() => {});
-      jest.spyOn(server['fieldDiscovery'], 'whenSettled').mockResolvedValue(undefined);
+      jest.spyOn(server['fieldDiscovery'], 'whenSettled').mockResolvedValue(true);
       const notify = jest.spyOn(server['server'], 'sendResourceListChanged').mockResolvedValue(undefined);
 
       await server.startBackgroundInit();
@@ -112,19 +112,55 @@ describe('SalesforceServer startup', () => {
 
     it('waits for discovery rather than announcing immediately', async () => {
       const server = new SalesforceServer();
-      let settle: () => void = () => {};
+      let settle: (ran: boolean) => void = () => {};
       jest.spyOn(server['fieldDiscovery'], 'startAsync').mockImplementation(() => {});
       jest.spyOn(server['fieldDiscovery'], 'whenSettled')
-        .mockReturnValue(new Promise<void>(res => { settle = res; }));
+        .mockReturnValue(new Promise<boolean>(res => { settle = res; }));
       const notify = jest.spyOn(server['server'], 'sendResourceListChanged').mockResolvedValue(undefined);
 
       const init = server.startBackgroundInit();
       await new Promise(process.nextTick);
       expect(notify).not.toHaveBeenCalled();
 
-      settle();
+      settle(true);
       await init;
       expect(notify).toHaveBeenCalledTimes(1);
+    });
+
+    // startBackgroundInit()'s promise must cover the announcement, not merely
+    // trigger it: run() and the tests both treat "init resolved" as "startup
+    // is done". Severing the chain (`void` instead of `return`) left both
+    // tests above passing on microtask ordering alone.
+    it('does not resolve until the announcement has completed', async () => {
+      const server = new SalesforceServer();
+      let finishNotify: () => void = () => {};
+      jest.spyOn(server['fieldDiscovery'], 'startAsync').mockImplementation(() => {});
+      jest.spyOn(server['fieldDiscovery'], 'whenSettled').mockResolvedValue(true);
+      jest.spyOn(server['server'], 'sendResourceListChanged')
+        .mockReturnValue(new Promise<void>(res => { finishNotify = res; }));
+
+      let resolved = false;
+      const init = server.startBackgroundInit().then(() => { resolved = true; });
+
+      await new Promise(process.nextTick);
+      expect(resolved).toBe(false);
+
+      finishNotify();
+      await init;
+      expect(resolved).toBe(true);
+    });
+
+    // whenSettled() reports whether discovery ran. Announcing a change that
+    // never happened would send clients to refetch an identical list.
+    it('does not announce when discovery was never started', async () => {
+      const server = new SalesforceServer();
+      jest.spyOn(server['fieldDiscovery'], 'startAsync').mockImplementation(() => {});
+      const notify = jest.spyOn(server['server'], 'sendResourceListChanged').mockResolvedValue(undefined);
+
+      // startAsync stubbed out, so whenSettled() reports false for real.
+      await server.startBackgroundInit();
+
+      expect(notify).not.toHaveBeenCalled();
     });
 
     it('does not announce when auth failed and discovery never ran', async () => {
@@ -140,7 +176,7 @@ describe('SalesforceServer startup', () => {
     it('survives a client that has gone away', async () => {
       const server = new SalesforceServer();
       jest.spyOn(server['fieldDiscovery'], 'startAsync').mockImplementation(() => {});
-      jest.spyOn(server['fieldDiscovery'], 'whenSettled').mockResolvedValue(undefined);
+      jest.spyOn(server['fieldDiscovery'], 'whenSettled').mockResolvedValue(true);
       jest.spyOn(server['server'], 'sendResourceListChanged')
         .mockRejectedValue(new Error('Not connected'));
 

--- a/src/__tests__/tool-schemas.test.ts
+++ b/src/__tests__/tool-schemas.test.ts
@@ -1,0 +1,58 @@
+/// <reference types="jest" />
+
+import { toolSchemas } from '../schemas/tool-schemas';
+
+/**
+ * Tool descriptions are the strongest instruction surface the server has: an
+ * agent reads them before it acts, on every call, whereas next-steps only land
+ * after one. `execute_soql` used to say "Use describe_object first to discover
+ * available fields" — a standing order to perform the reconnaissance round-trip
+ * that field discovery (ADR-300) exists to eliminate. Removing it from
+ * next-steps while leaving it here changed the polite suggestion and left the
+ * imperative.
+ */
+describe('tool schemas', () => {
+  it('exposes a description for every tool', () => {
+    const undescribed = Object.entries(toolSchemas)
+      .filter(([, s]) => typeof s.description !== 'string' || s.description.trim() === '')
+      .map(([name]) => name);
+
+    expect(undescribed).toEqual([]);
+  });
+
+  describe('execute_soql', () => {
+    const description = toolSchemas.execute_soql.description;
+
+    it('does not order the agent to describe an object before querying', () => {
+      expect(description).not.toMatch(/describe[_ ]object first/i);
+      expect(description).not.toMatch(/use\s+`?describe_object`?\s+(first|to discover)/i);
+    });
+
+    it('points at the field catalog as the cheaper route', () => {
+      expect(description).toContain('salesforce://field-catalog/');
+    });
+  });
+
+  describe('describe_object', () => {
+    const description = toolSchemas.describe_object.description;
+
+    it('does not present itself as the way to find queryable fields', () => {
+      // It returns the full schema — correct when you want everything, wasteful
+      // as a precursor to writing a SELECT.
+      expect(description).not.toMatch(/use this to discover available fields/i);
+    });
+
+    it('points at the catalog for the ranked view', () => {
+      expect(description).toContain('salesforce://field-catalog/');
+    });
+  });
+
+  it('no tool description instructs a discovery round-trip before real work', () => {
+    const offenders = Object.entries(toolSchemas)
+      .filter(([name]) => name !== 'describe_object' && name !== 'list_objects')
+      .filter(([, s]) => /(?:use|call|run)\s+`?describe_object`?\s+first/i.test(s.description))
+      .map(([name]) => name);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/__tests__/tool-schemas.test.ts
+++ b/src/__tests__/tool-schemas.test.ts
@@ -31,6 +31,24 @@ describe('tool schemas', () => {
     it('points at the field catalog as the cheaper route', () => {
       expect(description).toContain('salesforce://field-catalog/');
     });
+
+    // The catalog is a usage filter, not a field list — standard fields are
+    // absent by design (ADR-300). Naming it as the answer to "what can I
+    // select?" without that caveat invites the reader to conclude anything
+    // missing is unavailable, which is false. Every other surface that names
+    // the catalog carries this hedge; the tool description is read before
+    // every call, so it needs it most.
+    it('does not imply the catalog is the complete set of queryable fields', () => {
+      expect(description).toMatch(/standard fields remain queryable/i);
+    });
+
+    // A tool description is a promise made before the agent can check it.
+    // These were once asserted flatly and were false for any non-core object,
+    // and false for every object during the startup discovery window.
+    it('does not promise behaviour the server only sometimes delivers', () => {
+      expect(description).not.toMatch(/results carry/i);
+      expect(description).not.toMatch(/reports the fields that do/i);
+    });
   });
 
   describe('describe_object', () => {

--- a/src/client/field-discovery.ts
+++ b/src/client/field-discovery.ts
@@ -71,6 +71,19 @@ export class FieldDiscovery {
     });
   }
 
+  /**
+   * Resolves when startup discovery has settled — succeeded, or failed in a way
+   * the catalog has already absorbed. Never rejects: callers wait on this to
+   * react to discovery finishing, and a rejection would make them handle an
+   * error the discovery pipeline itself already logged and recorded in stats.
+   *
+   * Resolves immediately if startAsync() was never called; there is nothing to
+   * wait for. Call startAsync() first.
+   */
+  whenSettled(): Promise<void> {
+    return this.startupPromise ? this.startupPromise.catch(() => {}) : Promise.resolve();
+  }
+
   /** Get the catalog for an object (returns undefined if not yet discovered). */
   getCatalog(objectName: string): ObjectCatalog | undefined {
     return this.catalogs.get(objectName);

--- a/src/client/field-discovery.ts
+++ b/src/client/field-discovery.ts
@@ -72,16 +72,23 @@ export class FieldDiscovery {
   }
 
   /**
-   * Resolves when startup discovery has settled — succeeded, or failed in a way
-   * the catalog has already absorbed. Never rejects: callers wait on this to
-   * react to discovery finishing, and a rejection would make them handle an
-   * error the discovery pipeline itself already logged and recorded in stats.
+   * Wait for startup discovery to settle. Resolves `true` once it has run —
+   * whether it succeeded or failed in a way the catalog already absorbed — and
+   * `false` if it was never started, in which case there was nothing to wait
+   * for and nothing has changed.
    *
-   * Resolves immediately if startAsync() was never called; there is nothing to
-   * wait for. Call startAsync() first.
+   * The boolean is the point. Callers wait on this to react to discovery
+   * *landing*; a bare `Promise<void>` that resolves immediately when
+   * `startAsync()` was never called is indistinguishable from "discovery
+   * finished", so a caller would act on a state change that never happened.
+   *
+   * Never rejects: discovery logs its own failures and records them in stats,
+   * so re-raising here would force every caller to handle an error that has
+   * already been dealt with.
    */
-  whenSettled(): Promise<void> {
-    return this.startupPromise ? this.startupPromise.catch(() => {}) : Promise.resolve();
+  whenSettled(): Promise<boolean> {
+    if (!this.startupPromise) return Promise.resolve(false);
+    return this.startupPromise.then(() => true, () => true);
   }
 
   /** Get the catalog for an object (returns undefined if not yet discovered). */

--- a/src/index.ts
+++ b/src/index.ts
@@ -330,7 +330,9 @@ class SalesforceServer {
         this.fieldDiscovery.startAsync();
         // Tell clients to refetch once discovery lands. The list they cached at
         // connect describes every catalog as "in progress", because it was.
-        return this.fieldDiscovery.whenSettled().then(() => this.announceResourceChange());
+        // Only announce if discovery actually ran — nothing to refetch otherwise.
+        return this.fieldDiscovery.whenSettled()
+          .then(ran => (ran ? this.announceResourceChange() : undefined));
       })
       .catch((err) => {
         console.error(`Salesforce auth failed (will retry on first tool call): ${err.message}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,12 @@ class SalesforceServer {
       {
         capabilities: {
           tools: {},
-          resources: {},
+          // listChanged: the resource list is built before discovery has run
+          // (the transport connects first), so every description in it starts
+          // out saying "in progress". Clients cache that listing at connect and
+          // have no reason to refetch, so without this the labels stay wrong for
+          // the whole session while the resources themselves read fine.
+          resources: { listChanged: true },
         },
       }
     );
@@ -294,6 +299,21 @@ class SalesforceServer {
   }
 
   /**
+   * Notify clients that the resource list is worth refetching.
+   *
+   * Best-effort: this fires from a background chain after discovery settles, and
+   * a client that has already gone away must not turn a cosmetic refresh into an
+   * unhandled rejection that takes the server with it.
+   */
+  private async announceResourceChange(): Promise<void> {
+    try {
+      await this.server.sendResourceListChanged();
+    } catch (err: any) {
+      console.error(`Could not notify clients of resource changes: ${err?.message ?? err}`);
+    }
+  }
+
+  /**
    * Wait on the auth the constructor's warmup() already started, then kick off
    * field discovery. Separate from run() so it can be tested without binding
    * stdio — the double-login bug lived here and shipped unnoticed.
@@ -308,6 +328,9 @@ class SalesforceServer {
         // After auth succeeds, start field discovery (ADR-300).
         // Non-blocking — tools work immediately, discovery enriches over time.
         this.fieldDiscovery.startAsync();
+        // Tell clients to refetch once discovery lands. The list they cached at
+        // connect describes every catalog as "in progress", because it was.
+        return this.fieldDiscovery.whenSettled().then(() => this.announceResourceChange());
       })
       .catch((err) => {
         console.error(`Salesforce auth failed (will retry on first tool call): ${err.message}`);

--- a/src/schemas/tool-schemas.ts
+++ b/src/schemas/tool-schemas.ts
@@ -290,7 +290,7 @@ export const toolSchemas = {
   },
   execute_soql: {
     name: 'execute_soql',
-    description: 'Execute a SOQL query. Supports querying both standard and custom fields (custom fields end with __c in their API names). Use describe_object first to discover available fields.',
+    description: 'Execute a SOQL query. Supports both standard and custom fields (custom fields end with __c in their API names). You do not need to inspect an object before querying it: this org\'s most-populated fields are listed in the `salesforce://field-catalog/{objectName}` resource, results carry the same list, and a query naming a field that does not exist reports the fields that do. Reach for describe_object when you need an object\'s full schema, not to find out what to select.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -317,7 +317,7 @@ export const toolSchemas = {
   },
   describe_object: {
     name: 'describe_object',
-    description: 'Get metadata about a Salesforce object, including both standard and custom fields when includeFields is true. Use this to discover available fields and their API names, especially useful for finding custom fields (ending in __c)',
+    description: 'Get an object\'s full metadata, including every standard and custom field when includeFields is true. Returns the complete schema — exhaustive but unranked, and large on customised objects. To find out which fields this org actually populates, read `salesforce://field-catalog/{objectName}` instead; it is ranked and far smaller.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/schemas/tool-schemas.ts
+++ b/src/schemas/tool-schemas.ts
@@ -290,7 +290,7 @@ export const toolSchemas = {
   },
   execute_soql: {
     name: 'execute_soql',
-    description: 'Execute a SOQL query. Supports both standard and custom fields (custom fields end with __c in their API names). You do not need to inspect an object before querying it: this org\'s most-populated fields are listed in the `salesforce://field-catalog/{objectName}` resource, results carry the same list, and a query naming a field that does not exist reports the fields that do. Reach for describe_object when you need an object\'s full schema, not to find out what to select.',
+    description: 'Execute a SOQL query. Supports both standard and custom fields (custom fields end with __c in their API names). To see which fields this org actually populates on an object, read the `salesforce://field-catalog/{objectName}` resource — it is ranked, far smaller than a full schema, and works for any object. That catalog is a usage filter rather than a field list: standard fields remain queryable whether or not they appear in it. Use describe_object when you want an object\'s complete schema.',
     inputSchema: {
       type: 'object',
       properties: {


### PR DESCRIPTION
Found by reconnecting the MCP server and reading what it actually presents. Two related fixes, both about surfaces that lie to the agent.

## 1. The tool descriptions ordered a recon round-trip

`execute_soql`'s description said:

> Execute a SOQL query. … **Use describe_object first to discover available fields.**

#89 removed the recon-inducing suggestions from `next-steps.ts` and left this untouched — the weaker surface. Next-steps land *after* a call; the tool description is read *before* one, on every call. It's a standing order, not a suggestion.

It also answers the original question. Agents were performing reconnaissance before starting work **because the server told them to, in the first sentence they read.** Field discovery was built to make that round-trip unnecessary, and the tool description kept ordering it anyway.

`describe_object` had the softer version — "Use this to discover available fields" presents a full-schema dump as the way to find out what to select.

Both now point at the field catalog, hedged (see below). Guarded by tests, because "use describe_object first" is exactly the kind of helpful-sounding line that gets re-added.

## 2. Resource labels went stale for the whole session

The resource list is built before discovery can have run — the transport connects first — so every catalog is described as "discovery in progress". Clients cache that at connect and never refetch. Reads are live, so the data was right; only the labels lied, permanently.

Third costume for one root cause: a list built at the one moment discovery cannot have finished. #89 fixed it being *invisible*; this fixes it being *visibly wrong*.

Declares `resources: { listChanged: true }` and notifies once discovery settles. Both halves are needed — the SDK only checks `resources` is truthy, so the notification would have shipped while clients ignored it for want of the capability.

Verified against the live org: capability advertised as `{"listChanged":true}`, exactly one notification at **+7.3s**, and a refetch turns *"discovery in progress"* into *"6 objects, 200 promoted fields"*.

## What review caught

A `code-reviewer` pass found the first draft of this PR guilty of its own charge, and the fixes are in `eaf691a`:

- **The rewrite dropped the caveat every other surface carries.** `field-hints.ts` argues at length that naming the catalog without a hedge "invites the reader to conclude that anything missing from it is unavailable, which is false and the opposite of helpful" — and the hint output and resource template both obey it. The tool description, on the surface this PR argues is strongest, had no hedge at all.
- **Two of its three claims were conditionally false.** "Results carry the same list" holds only for the six core objects (the hint path has no on-demand discovery; the resource does). "Reports the fields that do" needs both a parseable error and a discovered catalog. **During the startup window fix #2 exists to address, all three were false.** It now promises only the catalog resource, which discovers on demand and therefore holds for any object at any time.
- **`whenSettled()` returned `Promise<void>`**, so "never started" was indistinguishable from "finished" — four existing tests silently drove that into a swallowed error. It now reports whether discovery ran, and the announce is guarded on it.
- **A mutation slipped the suite**: severing `startBackgroundInit()`'s promise from the announce (`void` for `return`) passed all 9 startup tests on microtask ordering. Now pinned.

## Verified

Live against the org, not just in tests: descriptions as served over stdio, capability as advertised in the initialize response, notification timing on the wire. Every fix mutation-checked — revert it, confirm the test goes red. 479 tests green.

## Known, not fixed here

If auth fails, discovery never starts and the labels stay "in progress" for the session. Not announcing is correct — nothing changed — but the stale-label problem persists on that path. Pre-existing; naming it rather than leaving it implied as covered.

Related: #90 (ADR-301) covers the deeper issue — that the catalog's ranking is drift-blind — and the pending-state work this touches.
