### PR TITLE
feat: search_fields tool for concept-to-field resolution (ADR-302)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,27 @@ If searching for "Project Status":
 
 ### Core Salesforce Operations
 
+#### search_fields
+Find the field(s) that carry a concept when you know what you want to query but not the API name. Searches the discovered field catalog ([ADR-302](docs/architecture/api/ADR-302-field-search-tool-for-concept-to-field-resolution.md)) by keyword across field API names, labels, and help text, ranked by match strength.
+```typescript
+{
+  term: string;             // Required: matched against field name, label, help text
+  objectName?: string;      // Optional: scope to one object (default: all core objects)
+  includeValues?: boolean;  // Optional: return active picklist values for matches (default: false)
+  minPopulationPct?: number;// Optional: drop fields below this population density (0-100)
+  limit?: number;           // Optional: max matches (default: 25, max: 100)
+}
+```
+Example:
+```javascript
+{
+  "term": "ai",
+  "objectName": "Opportunity",
+  "includeValues": true
+}
+```
+The match is lexical, not semantic: it finds fields whose metadata contains the term, so a concept the schema names differently won't surface — read `salesforce://field-catalog/{objectName}/all` to browse everything.
+
 #### execute_soql
 Execute a SOQL query with pagination support.
 ```typescript

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -33,3 +33,4 @@ _Salesforce API interaction, authentication, query patterns_
 |-----|-------|--------|
 | [ADR-300](./api/ADR-300-field-discovery-with-tiered-promotion-and-catalog-resources.md) | Field discovery with tiered promotion and catalog resources | Accepted |
 | [ADR-301](./api/ADR-301-sample-records-to-score-fields-and-weight-the-sample-by-recency.md) | Sample records to score fields, and weight the sample by recency | Accepted |
+| [ADR-302](./api/ADR-302-field-search-tool-for-concept-to-field-resolution.md) | Field search tool for concept-to-field resolution | Accepted |

--- a/docs/architecture/api/ADR-302-field-search-tool-for-concept-to-field-resolution.md
+++ b/docs/architecture/api/ADR-302-field-search-tool-for-concept-to-field-resolution.md
@@ -1,0 +1,137 @@
+---
+status: Accepted
+date: 2026-07-16
+deciders:
+  - aaronsb
+  - claude
+related:
+  - ADR-300
+  - ADR-301
+---
+
+# ADR-302: Field search tool for concept-to-field resolution
+
+## Context
+
+Field discovery (ADR-300) ranks and caches every field on the core objects and
+exposes the result as catalog resources. That solved *"which fields on this
+object matter?"* It did not solve the question that comes first in practice:
+*"I know what I want to filter or sum — which field is it?"*
+
+The catalog is organised by object. To answer "which field records whether a
+deal involved AI?" an agent must pull `salesforce://field-catalog/Opportunity/all`
+and scan it. In Claude Code that scan is a local `grep`; in a plain chat client
+(Claude Desktop) there is no local text-processing escape hatch, so the agent
+reads an 80KB JSON blob into context and eyeballs it — and the field it wants is
+often a 3-4% populated custom flag that is easy to skim past. The catalog holds
+the answer; nothing lets the agent *ask*.
+
+A concrete session drove this out. A user asked for total pipeline "attributed
+to AI" without knowing the field name. Resolving it took: (1) read the full
+catalog, (2) grep it for `ai`, finding `AI_Opportunity__c` and `AI_Delivery__c`,
+(3) run a `GROUP BY` query *just to learn the picklist values were `Yes`/`No`*,
+then (4) aggregate. Steps 1-3 are pure discovery overhead, they recur for every
+"which field is X" question, and step 1 is the one that degrades badly outside
+Claude Code.
+
+## Decision
+
+Add a `search_fields` tool: a lexical search over the discovered catalogs that
+returns the fields matching a term, ranked, optionally carrying their value
+sets. It is a read over already-discovered metadata — no new Salesforce calls on
+the hot path.
+
+### Matching
+
+Split the term into whitespace tokens and score each candidate field against its
+API name, label, and help text. Weighting encodes a signal hierarchy:
+
+| Signal | Weight | Rationale |
+|---|---|---|
+| Token is a name segment (`ai` in `ai_opportunity__c`) | +50 | Strongest — the field is *named* for it |
+| Name segment prefix | +30 | |
+| Substring anywhere in name (`ai` in `email`) | +15 | Weak — incidental |
+| Whole-word match in label | +40 | |
+| Substring in label | +12 | |
+| Substring in help text | +8 | Weakest, but disambiguates cryptic API names |
+
+Name and label contributions sum (a term in both is genuinely more relevant), and
+the total is scaled by token coverage so a hit on every word of a multi-word
+query outranks one that caught a single common word. Results sort by relevance,
+then the catalog's own usefulness score (ADR-300), then population, then name —
+deterministic, and ties break toward the field with real data behind it.
+
+The matcher is a **pure function** (`src/utils/field-search.ts`) fed the cached
+catalogs by the handler. It does no I/O, so its ranking is unit-testable without
+a Salesforce connection.
+
+### Value enrichment
+
+`includeValues: true` returns the active picklist values for matched categorical
+fields. This folds the step-3 round-trip into the search: a matched picklist
+comes back as `AI_Opportunity__c … values: [Yes, No]`, so the agent writes
+`WHERE AI_Opportunity__c = 'Yes'` directly. The values ride along on the describe
+discovery already performs (ADR-300) — captured into `FieldCandidate` at zero
+extra API cost, active values only, since inactive ones can't appear in a filter.
+
+### Scope
+
+Searches all discovered core objects by default; `objectName` narrows to one and
+discovers it on demand if the startup sweep hasn't reached it, mirroring the
+catalog resource. `minPopulationPct` filters by density but is **off by default**
+— sparse custom flags are exactly what this tool exists to find. `limit` defaults
+to 25, capped at 100: a search surface, not a dump (ADR-214).
+
+### What it deliberately is not
+
+- **Not semantic.** It matches strings in metadata. It finds `AI_Opportunity__c`
+  from "ai" because the characters are there; it will *not* find it from
+  "attribution", because nothing in the schema says "attribution". The response
+  says so, and points at the full catalog. Synonym/embedding resolution is a
+  possible future `mode`, deliberately deferred — it is real scope and easy to
+  get subtly wrong.
+- **Not a value sampler for free text.** `includeValues` returns picklist value
+  sets only (free, from metadata). Sampling distinct values of a free-text or
+  high-cardinality field means a live query per field and belongs behind its own
+  guard rail, not here (cf. ADR-301 sampling).
+- **Not a question-answerer.** It resolves concept → field and stops. The
+  judgement calls a real business question needs — which amount field, how to
+  bound a date range, whether to dedupe overlapping flags — stay with the caller,
+  where they are explicit and auditable, rather than hidden inside a tool.
+
+## Consequences
+
+### Positive
+
+- Concept → field resolution is one call, and it works identically in any MCP
+  client — the painful path (dump-and-grep) is gone where it hurt most.
+- `includeValues` removes the "now what values does it take?" round-trip.
+- Sparse, admin-created custom flags become discoverable by meaning, not just by
+  reading the whole catalog.
+- Pure matcher keeps ranking behaviour under test.
+
+### Negative
+
+- Lexical matching misses concepts the schema names unexpectedly. Mitigated by
+  the honest empty-result message and the catalog fallback, not hidden.
+- One more tool on the `ListTools` surface. Justified: it is the missing verb for
+  the discovery data ADR-300 already pays to build.
+
+### Neutral
+
+- Adds `picklistValues` to `FieldCandidate`. Additive; catalog resource output is
+  unchanged (it does not emit the field).
+- Depends on discovery having run. Before it lands, the tool says so rather than
+  returning a bare "0 matches" that reads as "this org has no such field".
+
+## Alternatives Considered
+
+- **A query parameter on the catalog resource** (`…/Opportunity?q=ai`). Rejected:
+  MCP resources are meant to be cheap passive reads; `includeValues` takes
+  parameters and has enrichment behaviour, which is a tool's job.
+- **Semantic matching from day one.** Rejected for v1 — high value but real scope
+  and failure modes; the lexical version covers the majority of real "which field
+  is X" cases cheaply. Left as a future `mode`.
+- **A natural-language "answer this business question" tool.** Rejected on
+  principle: it would bury the schema decisions that materially change the answer.
+  Keep the resolver dumb and composable.

--- a/docs/architecture/api/ADR-302-field-search-tool-for-concept-to-field-resolution.md
+++ b/docs/architecture/api/ADR-302-field-search-tool-for-concept-to-field-resolution.md
@@ -38,8 +38,9 @@ Claude Code.
 
 Add a `search_fields` tool: a lexical search over the discovered catalogs that
 returns the fields matching a term, ranked, optionally carrying their value
-sets. It is a read over already-discovered metadata — no new Salesforce calls on
-the hot path.
+sets. On its default path it is a read over already-discovered metadata and
+costs no Salesforce calls; naming an object the startup sweep has not reached
+discovers it first, at the usual cost of a discovery.
 
 ### Matching
 

--- a/src/__tests__/field-search-handler.test.ts
+++ b/src/__tests__/field-search-handler.test.ts
@@ -1,0 +1,106 @@
+/// <reference types="jest" />
+
+import { handleSearchFields } from '../handlers/field-search-handler';
+import type { ObjectCatalog } from '../client/field-discovery';
+import type { ScoredField, FieldCandidate } from '../utils/field-regulator';
+
+/**
+ * Handler-level behaviour the pure matcher can't cover: the rendered surface,
+ * on-demand scoping, and the two "say why, don't lie" empty paths — a bare
+ * "0 matches" reads as "this org has no such field", which is a different and
+ * wrong claim.
+ */
+
+function sf(partial: Partial<FieldCandidate> & { name: string }): ScoredField {
+  return {
+    field: {
+      label: partial.name, type: 'string', custom: true, helpText: null,
+      nillable: true, computationType: 'text', ...partial,
+    },
+    score: partial.populationPct ?? 0,
+    adjustments: [],
+    promoted: false,
+  };
+}
+
+function catalog(objectName: string, fields: ScoredField[]): ObjectCatalog {
+  return {
+    objectName, fields, promoted: fields.filter(f => f.promoted),
+    wellKnown: new Map(), describeMs: 0, scoringMs: 0,
+    totalFields: fields.length, totalRecords: 100,
+  };
+}
+
+/** Duck-typed FieldDiscovery — the handler only touches these three methods. */
+function fakeDiscovery(catalogs: ObjectCatalog[], onDemand?: ObjectCatalog) {
+  const byName = new Map(catalogs.map(c => [c.objectName, c]));
+  const discoverObject = jest.fn(async (name: string) => {
+    if (onDemand && onDemand.objectName === name) {
+      byName.set(name, onDemand);
+      return onDemand;
+    }
+    return null;
+  });
+  return {
+    fd: {
+      getCatalog: (n: string) => byName.get(n),
+      allCatalogs: () => [...byName.values()],
+      discoverObject,
+    } as any,
+    discoverObject,
+  };
+}
+
+const oppCatalog = catalog('Opportunity', [
+  sf({ name: 'AI_Opportunity__c', label: 'AI Sales', type: 'picklist', computationType: 'categorical', populationPct: 4, picklistValues: ['Yes', 'No'] }),
+  sf({ name: 'Amount', label: 'Amount', type: 'currency', computationType: 'numeric', populationPct: 100 }),
+]);
+
+async function text(res: any): Promise<string> {
+  return res.content[0].text as string;
+}
+
+describe('handleSearchFields', () => {
+  it('renders matched fields as a table', async () => {
+    const { fd } = fakeDiscovery([oppCatalog]);
+    const out = await text(await handleSearchFields(fd, { term: 'ai' }));
+    expect(out).toContain('AI_Opportunity__c');
+    expect(out).toContain('AI Sales');
+    expect(out).not.toContain('Amount'); // no "ai" in Amount
+  });
+
+  it('adds a Values column only when includeValues is set', async () => {
+    const { fd } = fakeDiscovery([oppCatalog]);
+    const plain = await text(await handleSearchFields(fd, { term: 'ai' }));
+    expect(plain).not.toContain('Values');
+
+    const withValues = await text(await handleSearchFields(fd, { term: 'ai', includeValues: true }));
+    expect(withValues).toContain('Values');
+    expect(withValues).toContain('Yes, No');
+  });
+
+  it('discovers a scoped object on demand when the catalog is cold', async () => {
+    const { fd, discoverObject } = fakeDiscovery([], oppCatalog);
+    const out = await text(await handleSearchFields(fd, { term: 'ai', objectName: 'Opportunity' }));
+    expect(discoverObject).toHaveBeenCalledWith('Opportunity');
+    expect(out).toContain('AI_Opportunity__c');
+  });
+
+  it('explains an empty catalog instead of claiming no field exists', async () => {
+    const { fd } = fakeDiscovery([]);
+    const out = await text(await handleSearchFields(fd, { term: 'ai' }));
+    expect(out).toMatch(/discovery may still be in progress|_stats/i);
+  });
+
+  it('says the match is lexical when nothing matches a populated catalog', async () => {
+    const { fd } = fakeDiscovery([oppCatalog]);
+    const out = await text(await handleSearchFields(fd, { term: 'zzznope' }));
+    expect(out).toMatch(/lexical/i);
+    expect(out).toContain('field-catalog');
+  });
+
+  it('rejects a missing term', async () => {
+    const { fd } = fakeDiscovery([oppCatalog]);
+    await expect(handleSearchFields(fd, {})).rejects.toThrow(/term/i);
+  });
+});

--- a/src/__tests__/field-search-handler.test.ts
+++ b/src/__tests__/field-search-handler.test.ts
@@ -103,4 +103,73 @@ describe('handleSearchFields', () => {
     const { fd } = fakeDiscovery([oppCatalog]);
     await expect(handleSearchFields(fd, {})).rejects.toThrow(/term/i);
   });
+
+  describe('objectName validation', () => {
+    // The object name is interpolated into SOQL during discovery
+    // (field-discovery.ts builds `SELECT COUNT() FROM ${objectName}`). The
+    // catalog resource guards this with the same pattern; the handler must not
+    // rely on describe() happening to reject it first.
+    it('rejects an object name that is not a plain identifier', async () => {
+      const { fd, discoverObject } = fakeDiscovery([oppCatalog]);
+
+      await expect(handleSearchFields(fd, { term: 'ai', objectName: "Opp' OR Id != '" }))
+        .rejects.toThrow(/Invalid Salesforce object name/i);
+      expect(discoverObject).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-string object name rather than mis-diagnosing it', async () => {
+      const { fd } = fakeDiscovery([oppCatalog]);
+
+      // Previously rendered "No field catalog is available for [object Object]",
+      // which blames discovery for what is an invalid argument.
+      await expect(handleSearchFields(fd, { term: 'ai', objectName: { evil: true } }))
+        .rejects.toThrow(/must be a string/i);
+    });
+  });
+
+  // SOQL is case-insensitive, so an agent will write `opportunity`. Missing the
+  // cache would re-discover the object under a second key, and the duplicate's
+  // promoted fields push the already-binding global budget further past its cap
+  // — demoting fields on *other* objects. A read-only search must not degrade
+  // unrelated surfaces.
+  it('resolves a differently-cased object name to the cached catalog', async () => {
+    const { fd, discoverObject } = fakeDiscovery([oppCatalog]);
+
+    const out = await text(await handleSearchFields(fd, { term: 'ai', objectName: 'opportunity' }));
+
+    expect(discoverObject).not.toHaveBeenCalled();
+    expect(out).toContain('AI_Opportunity__c');
+  });
+
+  describe('numeric arguments', () => {
+    // NaN is a number, survives Math.min/max, and reaches slice(0, NaN) -> [],
+    // which renders as "no fields matched" — a plumbing failure reported as a
+    // claim about the org's schema. That is the bug class this repo has now
+    // fixed three times.
+    it('falls back to the default limit rather than reporting no matches', async () => {
+      const { fd } = fakeDiscovery([oppCatalog]);
+
+      const out = await text(await handleSearchFields(fd, { term: 'ai', limit: NaN }));
+
+      expect(out).not.toMatch(/matched "ai"/i);
+      expect(out).toContain('AI_Opportunity__c');
+    });
+
+    it('ignores a non-finite minPopulationPct rather than filtering everything out', async () => {
+      const { fd } = fakeDiscovery([oppCatalog]);
+
+      const out = await text(await handleSearchFields(fd, { term: 'ai', minPopulationPct: NaN }));
+
+      expect(out).toContain('AI_Opportunity__c');
+    });
+
+    it('clamps an out-of-range minPopulationPct instead of matching nothing', async () => {
+      const { fd } = fakeDiscovery([oppCatalog]);
+
+      const out = await text(await handleSearchFields(fd, { term: 'ai', minPopulationPct: 150 }));
+
+      // Clamped to 100 — a real filter, not an accidental empty result.
+      expect(out).toMatch(/matched "ai"|AI_Opportunity__c/);
+    });
+  });
 });

--- a/src/__tests__/field-search.test.ts
+++ b/src/__tests__/field-search.test.ts
@@ -1,0 +1,126 @@
+/// <reference types="jest" />
+
+import { searchFields, scoreFieldMatch, FieldSearchInput } from '../utils/field-search';
+import type { ScoredField, FieldCandidate } from '../utils/field-regulator';
+
+/**
+ * The matcher is the whole risk surface of ADR-302: it decides what "ai" means
+ * against a wall of field metadata. These tests pin the behaviour that makes it
+ * useful — segment matches beat substrings, requested values ride along, sparse
+ * custom flags are reachable — and the behaviour that keeps it honest: it is
+ * lexical, so a concept the schema doesn't name lexically does not surface.
+ */
+
+function field(partial: Partial<FieldCandidate> & { name: string }): ScoredField {
+  return {
+    field: {
+      label: partial.name,
+      type: 'string',
+      custom: true,
+      helpText: null,
+      nillable: true,
+      computationType: 'text',
+      ...partial,
+    },
+    score: partial.populationPct ?? 0,
+    adjustments: [],
+    promoted: false,
+  };
+}
+
+function input(objectName: string, sf: ScoredField): FieldSearchInput {
+  return { objectName, field: sf };
+}
+
+describe('scoreFieldMatch', () => {
+  it('scores a name-segment match above a substring buried in a longer word', () => {
+    const flag = scoreFieldMatch(['ai'], { name: 'AI_Opportunity__c', label: 'AI Sales', helpText: null });
+    const email = scoreFieldMatch(['ai'], { name: 'Email__c', label: 'Email', helpText: null });
+
+    expect(flag).not.toBeNull();
+    expect(email).not.toBeNull(); // "ai" is a substring of "email" — still a (weak) hit
+    expect(flag!.relevance).toBeGreaterThan(email!.relevance);
+  });
+
+  it('reports every metadata source the term matched on', () => {
+    const m = scoreFieldMatch(['ai'], {
+      name: 'AI_Opportunity__c',
+      label: 'AI Sales',
+      helpText: 'Flag for AI-driven deals',
+    });
+    expect(m!.matchedOn.sort()).toEqual(['helpText', 'label', 'name']);
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(scoreFieldMatch(['renewal'], { name: 'Amount', label: 'Amount', helpText: null })).toBeNull();
+  });
+
+  it('rewards covering more of a multi-word query', () => {
+    const both = scoreFieldMatch(['ai', 'delivery'], {
+      name: 'AI_Delivery__c', label: 'AI Augmented Delivery', helpText: null,
+    });
+    const one = scoreFieldMatch(['ai', 'delivery'], {
+      name: 'AI_Opportunity__c', label: 'AI Sales', helpText: null,
+    });
+    expect(both!.relevance).toBeGreaterThan(one!.relevance);
+  });
+});
+
+describe('searchFields', () => {
+  const catalog: FieldSearchInput[] = [
+    input('Opportunity', field({ name: 'AI_Opportunity__c', label: 'AI Sales', type: 'picklist', computationType: 'categorical', populationPct: 4, picklistValues: ['Yes', 'No'] })),
+    input('Opportunity', field({ name: 'AI_Delivery__c', label: 'AI Augmented Delivery', type: 'picklist', computationType: 'categorical', populationPct: 3, picklistValues: ['Yes', 'No'] })),
+    input('Opportunity', field({ name: 'Email__c', label: 'Email', populationPct: 90 })),
+    input('Account', field({ name: 'Amount', label: 'Amount', type: 'currency', computationType: 'numeric', populationPct: 100 })),
+  ];
+
+  it('finds the AI flags and ranks them above an incidental substring hit', () => {
+    const hits = searchFields('ai', catalog);
+    const names = hits.map(h => h.name);
+    expect(names.slice(0, 2).sort()).toEqual(['AI_Delivery__c', 'AI_Opportunity__c']);
+    // Email__c only matches because "ai" ⊂ "email"; it must rank last of the hits.
+    expect(names[names.length - 1]).toBe('Email__c');
+    expect(names).not.toContain('Amount');
+  });
+
+  it('reaches sparsely-populated custom flags (the whole point)', () => {
+    const hits = searchFields('ai', catalog);
+    const flag = hits.find(h => h.name === 'AI_Opportunity__c');
+    expect(flag).toBeDefined();
+    expect(flag!.populationPct).toBe(4); // 4% populated, still surfaced
+    expect(flag!.promoted).toBe(false);
+  });
+
+  it('omits picklist values unless includeValues is set', () => {
+    const without = searchFields('ai', catalog).find(h => h.name === 'AI_Opportunity__c');
+    expect(without!.values).toBeUndefined();
+
+    const withValues = searchFields('ai', catalog, { includeValues: true })
+      .find(h => h.name === 'AI_Opportunity__c');
+    expect(withValues!.values).toEqual(['Yes', 'No']);
+  });
+
+  it('filters by minPopulationPct', () => {
+    const hits = searchFields('ai', catalog, { minPopulationPct: 50 });
+    // Only Email__c (90%) clears the bar and still matches "ai".
+    expect(hits.map(h => h.name)).toEqual(['Email__c']);
+  });
+
+  it('respects the result limit', () => {
+    expect(searchFields('ai', catalog, { limit: 1 })).toHaveLength(1);
+  });
+
+  it('returns nothing for an empty term', () => {
+    expect(searchFields('   ', catalog)).toEqual([]);
+  });
+
+  it('breaks relevance ties deterministically by catalog score then population', () => {
+    const tie: FieldSearchInput[] = [
+      input('A', field({ name: 'Region_Low__c', label: 'Region', populationPct: 10 })),
+      input('B', field({ name: 'Region_High__c', label: 'Region', populationPct: 80 })),
+    ];
+    const hits = searchFields('region', tie);
+    // Equal relevance (same label word match); higher score/population wins.
+    expect(hits[0].name).toBe('Region_High__c');
+  });
+});

--- a/src/__tests__/field-search.test.ts
+++ b/src/__tests__/field-search.test.ts
@@ -11,7 +11,15 @@ import type { ScoredField, FieldCandidate } from '../utils/field-regulator';
  * lexical, so a concept the schema doesn't name lexically does not surface.
  */
 
-function field(partial: Partial<FieldCandidate> & { name: string }): ScoredField {
+/**
+ * `score` defaults to populationPct for brevity, but is settable independently:
+ * the two are separate tie-break levels, and a fixture that conflates them
+ * cannot tell which one fired.
+ */
+function field(
+  partial: Partial<FieldCandidate> & { name: string },
+  score?: number,
+): ScoredField {
   return {
     field: {
       label: partial.name,
@@ -22,7 +30,7 @@ function field(partial: Partial<FieldCandidate> & { name: string }): ScoredField
       computationType: 'text',
       ...partial,
     },
-    score: partial.populationPct ?? 0,
+    score: score ?? partial.populationPct ?? 0,
     adjustments: [],
     promoted: false,
   };
@@ -122,5 +130,40 @@ describe('searchFields', () => {
     const hits = searchFields('region', tie);
     // Equal relevance (same label word match); higher score/population wins.
     expect(hits[0].name).toBe('Region_High__c');
+  });
+
+  // score and population are separate levels. With the fixture conflating them,
+  // either could be deleted and the test above would still pass.
+  it('prefers catalog score over population when they disagree', () => {
+    const tie: FieldSearchInput[] = [
+      input('A', field({ name: 'Region_Dense__c', label: 'Region', populationPct: 90 }, 10)),
+      input('B', field({ name: 'Region_Ranked__c', label: 'Region', populationPct: 20 }, 90)),
+    ];
+
+    const hits = searchFields('region', tie);
+
+    expect(hits[0].name).toBe('Region_Ranked__c');
+  });
+
+  // Standard fields share a name across objects, so name alone leaves ties
+  // unresolved and order falls back to catalog insertion — which is the
+  // completion order of parallel discovery, i.e. network timing. Without an
+  // object tie-break the same search returns different rows across restarts.
+  it('breaks an identical-name tie by object, not by discovery order', () => {
+    const sameName = () => field({ name: 'Name', label: 'Name', populationPct: 100 }, 100);
+    const forward: FieldSearchInput[] = [
+      input('Opportunity', sameName()),
+      input('Account', sameName()),
+    ];
+    const reversed: FieldSearchInput[] = [
+      input('Account', sameName()),
+      input('Opportunity', sameName()),
+    ];
+
+    const a = searchFields('name', forward).map(h => h.object);
+    const b = searchFields('name', reversed).map(h => h.object);
+
+    expect(a).toEqual(['Account', 'Opportunity']);
+    expect(b).toEqual(a);
   });
 });

--- a/src/__tests__/tool-schemas.test.ts
+++ b/src/__tests__/tool-schemas.test.ts
@@ -65,6 +65,31 @@ describe('tool schemas', () => {
     });
   });
 
+  describe('search_fields', () => {
+    const description = toolSchemas.search_fields.description;
+
+    // "the field catalog" is ambiguous in this repo's own vocabulary:
+    // salesforce://field-catalog/{obj} is the *promoted* set, /all is every
+    // scored field. This tool searches every scored field, so an agent that has
+    // internalised "catalog = promoted, standard fields absent" would otherwise
+    // read the description and conclude the opposite.
+    it('says it searches every scored field, not just promoted ones', () => {
+      expect(description).toMatch(/not just the promoted/i);
+    });
+
+    // Default scope is the core objects. A 0-hit search reads as "this org has
+    // no such field" unless the description admits what it did not look at.
+    it('admits that undiscovered objects are not searched', () => {
+      expect(description).toMatch(/not been discovered is not searched/i);
+    });
+
+    // The example named two fields that exist only in the author's org — a
+    // promise false for every other caller, on the surface read before use.
+    it('does not cite org-specific field names as examples', () => {
+      expect(description).not.toMatch(/__c/);
+    });
+  });
+
   it('no tool description instructs a discovery round-trip before real work', () => {
     const offenders = Object.entries(toolSchemas)
       .filter(([name]) => name !== 'describe_object' && name !== 'list_objects')

--- a/src/client/field-discovery.ts
+++ b/src/client/field-discovery.ts
@@ -96,6 +96,11 @@ export class FieldDiscovery {
     return this.catalogs.get(objectName);
   }
 
+  /** All discovered catalogs, for surfaces that search across objects (ADR-302). */
+  allCatalogs(): ObjectCatalog[] {
+    return [...this.catalogs.values()];
+  }
+
   /** Resolve a well-known semantic field name to its actual API name on this org. */
   resolveWellKnown(objectName: string, semantic: string): string | undefined {
     return this.catalogs.get(objectName)?.wellKnown.get(semantic);
@@ -176,6 +181,13 @@ export class FieldDiscovery {
       helpText: f.inlineHelpText || null,
       nillable: f.nillable,
       computationType: getComputationType(f.type).computationType,
+      // Picklist values ride along on the describe we already fetched — no extra
+      // API cost. Kept so field search (ADR-302) can answer "what values does
+      // this field take?" in the same call that finds it. Active values only:
+      // inactive ones can't appear in a WHERE clause the agent would write next.
+      picklistValues: Array.isArray(f.picklistValues) && f.picklistValues.length > 0
+        ? f.picklistValues.filter((p: any) => p?.active !== false).map((p: any) => p.value)
+        : undefined,
     }));
 
     // 3. Population scoring

--- a/src/handlers/field-search-handler.ts
+++ b/src/handlers/field-search-handler.ts
@@ -1,0 +1,128 @@
+/**
+ * ADR-302 Field Search handler — the concept→field entry point.
+ *
+ * Turns a free-text term into a ranked list of the fields that carry it, drawn
+ * from the discovered catalogs (ADR-300). This is the step that was otherwise a
+ * fetch-the-whole-catalog-and-grep-it chore, collapsed into one call — and, with
+ * `includeValues`, it folds in the follow-up round-trip too: a matched picklist
+ * comes back with its value set, so the agent can write `WHERE Field = 'Yes'`
+ * without a separate probe.
+ */
+
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { FieldDiscovery } from '../client/field-discovery.js';
+import {
+  searchFields, FieldSearchInput, FieldSearchHit,
+  DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT,
+} from '../utils/field-search.js';
+import { simpleResponse } from '../utils/response-helper.js';
+
+interface SearchFieldsParams {
+  term: string;
+  objectName?: string;
+  includeValues?: boolean;
+  minPopulationPct?: number;
+  limit?: number;
+}
+
+function isSearchFieldsParams(obj: any): obj is SearchFieldsParams {
+  return typeof obj === 'object' && obj !== null &&
+    typeof obj.term === 'string' && obj.term.trim() !== '';
+}
+
+/** Flatten a set of catalogs into the (object, field) pairs the matcher wants. */
+function candidatesFrom(fd: FieldDiscovery, objectName?: string): FieldSearchInput[] {
+  const catalogs = objectName
+    ? [fd.getCatalog(objectName)].filter((c): c is NonNullable<typeof c> => !!c)
+    : fd.allCatalogs();
+
+  const inputs: FieldSearchInput[] = [];
+  for (const catalog of catalogs) {
+    for (const field of catalog.fields) {
+      inputs.push({ objectName: catalog.objectName, field });
+    }
+  }
+  return inputs;
+}
+
+function renderHits(term: string, hits: FieldSearchHit[], includeValues: boolean): string {
+  const lines: string[] = [`# Field search: "${term}" — ${hits.length} match${hits.length === 1 ? '' : 'es'}`];
+  lines.push('');
+
+  const header = ['Object', 'Field', 'Label', 'Type', 'Pop%', 'Promoted', 'Matched'];
+  if (includeValues) header.push('Values');
+  lines.push(header.join(' | '));
+  lines.push(header.map(() => '---').join(' | '));
+
+  for (const h of hits) {
+    const row = [
+      h.object,
+      h.name,
+      h.label || '',
+      h.type,
+      h.populationPct != null ? String(h.populationPct) : '—',
+      h.promoted ? 'yes' : 'no',
+      h.matchedOn.join('+'),
+    ];
+    if (includeValues) {
+      row.push(h.values ? h.values.join(', ') : '—');
+    }
+    lines.push(row.join(' | '));
+  }
+
+  return lines.join('\n');
+}
+
+export async function handleSearchFields(fd: FieldDiscovery, args: any) {
+  if (!isSearchFieldsParams(args)) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      'search_fields requires a non-empty `term` string',
+    );
+  }
+
+  const includeValues = args.includeValues === true;
+  const limit = typeof args.limit === 'number'
+    ? Math.max(1, Math.min(args.limit, MAX_SEARCH_LIMIT))
+    : DEFAULT_SEARCH_LIMIT;
+
+  // Scope to one object on request — discovering it on demand if the startup
+  // sweep hasn't reached it, exactly as the catalog resource does.
+  if (args.objectName && !fd.getCatalog(args.objectName)) {
+    await fd.discoverObject(args.objectName);
+  }
+
+  const candidates = candidatesFrom(fd, args.objectName);
+
+  // Nothing to search means discovery hasn't landed (or the named object
+  // couldn't be discovered). Say so rather than returning a bare "0 matches",
+  // which reads as "this org has no AI field" — a confidently wrong answer.
+  if (candidates.length === 0) {
+    const scope = args.objectName ? ` for ${args.objectName}` : '';
+    return simpleResponse(
+      `No field catalog is available${scope} yet — discovery may still be in ` +
+      `progress. Read \`salesforce://field-catalog/_stats\` to check status, ` +
+      `or retry shortly.`,
+      'search_fields',
+    );
+  }
+
+  const hits = searchFields(args.term, candidates, {
+    includeValues,
+    limit,
+    ...(typeof args.minPopulationPct === 'number' ? { minPopulationPct: args.minPopulationPct } : {}),
+  });
+
+  if (hits.length === 0) {
+    const scope = args.objectName ? ` on ${args.objectName}` : ' on any discovered object';
+    return simpleResponse(
+      `No fields${scope} matched "${args.term}". The match is lexical — it looks ` +
+      `at field API names, labels, and help text — so a concept named differently ` +
+      `in the schema won't surface. Try a synonym, or read the full catalog: ` +
+      `\`salesforce://field-catalog/${args.objectName ?? '{object}'}/all\`.`,
+      'search_fields',
+    );
+  }
+
+  return simpleResponse(renderHits(args.term, hits, includeValues), 'search_fields');
+}

--- a/src/handlers/field-search-handler.ts
+++ b/src/handlers/field-search-handler.ts
@@ -15,6 +15,7 @@ import {
   searchFields, FieldSearchInput, FieldSearchHit,
   DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT,
 } from '../utils/field-search.js';
+import { CORE_OBJECTS } from '../utils/discovery-constants.js';
 import { simpleResponse } from '../utils/response-helper.js';
 
 interface SearchFieldsParams {
@@ -28,6 +29,22 @@ interface SearchFieldsParams {
 function isSearchFieldsParams(obj: any): obj is SearchFieldsParams {
   return typeof obj === 'object' && obj !== null &&
     typeof obj.term === 'string' && obj.term.trim() !== '';
+}
+
+/**
+ * Resolve an object name to the key its catalog is stored under.
+ *
+ * SOQL is case-insensitive, so an agent will write `opportunity` as readily as
+ * `Opportunity`, but the catalog is keyed by exact API name. Matching the
+ * spelling as written would miss the cache and re-discover the object under a
+ * second key — which is worse than slow: `allCatalogs()` would then return
+ * every Opportunity field twice, and the duplicate's promoted fields would push
+ * the global budget further past its cap, demoting fields on *other* objects.
+ * A read-only search must not degrade the hints on unrelated surfaces.
+ */
+function canonicalObjectName(fd: FieldDiscovery, objectName: string): string {
+  if (fd.getCatalog(objectName)) return objectName;
+  return CORE_OBJECTS.find(o => o.toLowerCase() === objectName.toLowerCase()) ?? objectName;
 }
 
 /** Flatten a set of catalogs into the (object, field) pairs the matcher wants. */
@@ -82,23 +99,49 @@ export async function handleSearchFields(fd: FieldDiscovery, args: any) {
   }
 
   const includeValues = args.includeValues === true;
-  const limit = typeof args.limit === 'number'
-    ? Math.max(1, Math.min(args.limit, MAX_SEARCH_LIMIT))
+  // Number.isFinite, not typeof: NaN is a number, and it survives the clamp
+  // (Math.min(NaN, 100) is NaN) all the way to slice(0, NaN), which returns []
+  // and renders as "no fields matched" — a plumbing failure dressed up as a
+  // claim about the org's schema.
+  const limit = Number.isFinite(args.limit as number)
+    ? Math.max(1, Math.min(args.limit as number, MAX_SEARCH_LIMIT))
     : DEFAULT_SEARCH_LIMIT;
+  const minPopulationPct = Number.isFinite(args.minPopulationPct as number)
+    ? Math.max(0, Math.min(args.minPopulationPct as number, 100))
+    : undefined;
+
+  if (args.objectName !== undefined && typeof args.objectName !== 'string') {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      'search_fields `objectName` must be a string',
+    );
+  }
+
+  // Same shape as the catalog resource's guard (index.ts): an object name is
+  // interpolated into SOQL during discovery, so validate it here rather than
+  // relying on describe() to reject it first.
+  if (args.objectName !== undefined && !/^[A-Za-z]\w*$/.test(args.objectName)) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `Invalid Salesforce object name: "${args.objectName}"`,
+    );
+  }
+
+  const objectName = args.objectName ? canonicalObjectName(fd, args.objectName) : undefined;
 
   // Scope to one object on request — discovering it on demand if the startup
   // sweep hasn't reached it, exactly as the catalog resource does.
-  if (args.objectName && !fd.getCatalog(args.objectName)) {
-    await fd.discoverObject(args.objectName);
+  if (objectName && !fd.getCatalog(objectName)) {
+    await fd.discoverObject(objectName);
   }
 
-  const candidates = candidatesFrom(fd, args.objectName);
+  const candidates = candidatesFrom(fd, objectName);
 
   // Nothing to search means discovery hasn't landed (or the named object
   // couldn't be discovered). Say so rather than returning a bare "0 matches",
   // which reads as "this org has no AI field" — a confidently wrong answer.
   if (candidates.length === 0) {
-    const scope = args.objectName ? ` for ${args.objectName}` : '';
+    const scope = objectName ? ` for ${objectName}` : '';
     return simpleResponse(
       `No field catalog is available${scope} yet — discovery may still be in ` +
       `progress. Read \`salesforce://field-catalog/_stats\` to check status, ` +
@@ -110,16 +153,16 @@ export async function handleSearchFields(fd: FieldDiscovery, args: any) {
   const hits = searchFields(args.term, candidates, {
     includeValues,
     limit,
-    ...(typeof args.minPopulationPct === 'number' ? { minPopulationPct: args.minPopulationPct } : {}),
+    ...(minPopulationPct !== undefined ? { minPopulationPct } : {}),
   });
 
   if (hits.length === 0) {
-    const scope = args.objectName ? ` on ${args.objectName}` : ' on any discovered object';
+    const scope = objectName ? ` on ${objectName}` : ' on any discovered object';
     return simpleResponse(
       `No fields${scope} matched "${args.term}". The match is lexical — it looks ` +
       `at field API names, labels, and help text — so a concept named differently ` +
       `in the schema won't surface. Try a synonym, or read the full catalog: ` +
-      `\`salesforce://field-catalog/${args.objectName ?? '{object}'}/all\`.`,
+      `\`salesforce://field-catalog/${objectName ?? '{object}'}/all\`.`,
       'search_fields',
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { SalesforceClient } from './client/salesforce-client.js';
 import { handleExecuteSOQL } from './handlers/query-handlers.js';
 import { handleSearchOpportunities, handleGetOpportunityDetails } from './handlers/opportunity-handlers.js';
 import { handleDescribeObject, handleListObjects } from './handlers/object-handlers.js';
+import { handleSearchFields } from './handlers/field-search-handler.js';
 import { handleCreateRecord, handleUpdateRecord, handleDeleteRecord } from './handlers/record-handlers.js';
 import { handleGetUserInfo } from './handlers/user-handlers.js';
 import { handleAnalyzeConversation } from './handlers/conversation-handlers.js';
@@ -233,6 +234,9 @@ class SalesforceServer {
 
           case 'describe_object':
             return await handleDescribeObject(this.sfClient, request.params.arguments, this.cacheMiddleware);
+
+          case 'search_fields':
+            return await handleSearchFields(this.fieldDiscovery, request.params.arguments);
 
           case 'create_record':
             return await handleCreateRecord(this.sfClient, request.params.arguments, this.cacheMiddleware);

--- a/src/schemas/tool-schemas.ts
+++ b/src/schemas/tool-schemas.ts
@@ -288,6 +288,36 @@ export const toolSchemas = {
       }
     },
   },
+  search_fields: {
+    name: 'search_fields',
+    description: 'Find the field(s) that carry a concept, when you know what you want to query but not the API name. Searches the discovered field catalog by keyword across field API names, labels, and help text, ranked by match strength — e.g. "ai" surfaces AI_Opportunity__c and AI_Delivery__c. Searches all core objects by default; pass objectName to scope to one. Set includeValues to get the value set for matched picklists, so you can write the WHERE clause without a second lookup. The match is lexical, not semantic: it finds fields whose name/label/help text contains the term, so a concept the schema names differently won\'t surface — read `salesforce://field-catalog/{objectName}/all` to browse everything.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        term: {
+          type: 'string',
+          description: 'What to look for, matched against field API names, labels, and help text (e.g. "ai", "renewal date", "region")',
+        },
+        objectName: {
+          type: 'string',
+          description: 'Restrict the search to one object (e.g. Opportunity). Omit to search all discovered core objects.',
+        },
+        includeValues: {
+          type: 'boolean',
+          description: 'Include the active value set for matched picklist fields (default: false). Free — the values come from metadata already discovered.',
+        },
+        minPopulationPct: {
+          type: 'number',
+          description: 'Drop fields populated on fewer than this percent of records (0-100). Omit to include sparsely-populated fields, which is often where custom flags live.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum matches to return (default: 25, max: 100)',
+        },
+      },
+      required: ['term'],
+    },
+  },
   execute_soql: {
     name: 'execute_soql',
     description: 'Execute a SOQL query. Supports both standard and custom fields (custom fields end with __c in their API names). To see which fields this org actually populates on an object, read the `salesforce://field-catalog/{objectName}` resource — it is ranked, far smaller than a full schema, and works for any object. That catalog is a usage filter rather than a field list: standard fields remain queryable whether or not they appear in it. Use describe_object when you want an object\'s complete schema.',

--- a/src/schemas/tool-schemas.ts
+++ b/src/schemas/tool-schemas.ts
@@ -290,7 +290,7 @@ export const toolSchemas = {
   },
   search_fields: {
     name: 'search_fields',
-    description: 'Find the field(s) that carry a concept, when you know what you want to query but not the API name. Searches the discovered field catalog by keyword across field API names, labels, and help text, ranked by match strength — e.g. "ai" surfaces AI_Opportunity__c and AI_Delivery__c. Searches all core objects by default; pass objectName to scope to one. Set includeValues to get the value set for matched picklists, so you can write the WHERE clause without a second lookup. The match is lexical, not semantic: it finds fields whose name/label/help text contains the term, so a concept the schema names differently won\'t surface — read `salesforce://field-catalog/{objectName}/all` to browse everything.',
+    description: 'Find the field(s) that carry a concept, when you know what you want to query but not the API name. Searches every scored field on the discovered objects — not just the promoted ones — across API names, labels, and help text, ranked by match strength. Searches the core objects by default; pass objectName to scope to one, which discovers it on demand. Set includeValues to get the value set for matched picklists, so you can write the WHERE clause without a second lookup. The match is lexical, not semantic: it finds fields whose name, label or help text contains the term, so a concept this org names differently will not surface, and an object that has not been discovered is not searched. Read `salesforce://field-catalog/{objectName}/all` to browse everything on an object.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/utils/field-regulator.ts
+++ b/src/utils/field-regulator.ts
@@ -21,6 +21,8 @@ export interface FieldCandidate {
   computationType: ComputationType;
   /** Population percentage (0-100), undefined if not scored. */
   populationPct?: number;
+  /** Active picklist values, for categorical fields. Undefined otherwise. */
+  picklistValues?: string[];
 }
 
 export interface ScoreAdjustment {

--- a/src/utils/field-search.ts
+++ b/src/utils/field-search.ts
@@ -14,10 +14,10 @@
  * deterministic and unit-testable without a Salesforce connection.
  *
  * Deliberately *lexical*, not semantic (ADR-302). It matches the term against
- * the field's API name, label, and help text. It will find `AI_Opportunity__c`
- * from "ai" because the string is there; it will not find it from "attribution"
- * because nothing in the metadata says "attribution". That leap is the caller's
- * to make — the tool narrows the haystack, it doesn't read minds.
+ * the field's API name, label, and help text. A field named `Renewal_Risk__c`
+ * is found from "risk" because the string is there; it is not found from
+ * "churn" because nothing in the metadata says "churn". That leap is the
+ * caller's to make — the tool narrows the haystack, it doesn't read minds.
  */
 
 import type { ScoredField } from './field-regulator.js';
@@ -192,11 +192,19 @@ export function searchFields(
     });
   }
 
+  // Object is part of the tie-break, not decoration. Standard fields share a
+  // name across objects — Name, CreatedDate and OwnerId exist on all of them —
+  // so name alone leaves ties unresolved. A stable sort then falls back to
+  // input order, which is catalog insertion order, which is the completion
+  // order of parallel discovery tasks: network timing. Without this the same
+  // search returns a different object's Name first across restarts, and with
+  // `limit` truncation it drops different rows.
   hits.sort((a, b) =>
     b.relevance - a.relevance ||
     b.score - a.score ||
     (b.populationPct ?? 0) - (a.populationPct ?? 0) ||
-    a.name.localeCompare(b.name),
+    a.name.localeCompare(b.name) ||
+    a.object.localeCompare(b.object),
   );
 
   return hits.slice(0, limit);

--- a/src/utils/field-search.ts
+++ b/src/utils/field-search.ts
@@ -1,0 +1,203 @@
+/**
+ * ADR-302 Field Search — resolve a concept to the fields that carry it.
+ *
+ * Field discovery (ADR-300) already ranks and caches every field on the core
+ * objects. But it is organised *by object*: to answer "which field records
+ * whether a deal involved AI?" an agent has to pull a whole catalog and read
+ * it, and in a client without local text-processing (a plain chat UI) that
+ * means eyeballing an 80KB blob for a 4%-populated custom field. The catalog
+ * knows the answer; nothing lets the agent ask the question.
+ *
+ * This module is the matcher: a pure function over already-discovered fields
+ * that ranks them against a search term. It does no I/O — the handler feeds it
+ * the cached catalogs and renders what comes back — so the scoring is
+ * deterministic and unit-testable without a Salesforce connection.
+ *
+ * Deliberately *lexical*, not semantic (ADR-302). It matches the term against
+ * the field's API name, label, and help text. It will find `AI_Opportunity__c`
+ * from "ai" because the string is there; it will not find it from "attribution"
+ * because nothing in the metadata says "attribution". That leap is the caller's
+ * to make — the tool narrows the haystack, it doesn't read minds.
+ */
+
+import type { ScoredField } from './field-regulator.js';
+
+/** A discovered field paired with the object it belongs to. */
+export interface FieldSearchInput {
+  objectName: string;
+  field: ScoredField;
+}
+
+/** Options controlling which fields come back and how many. */
+export interface FieldSearchOptions {
+  /** Restrict to fields at or above this population density (0-100). */
+  minPopulationPct?: number;
+  /** Include picklist value sets on matched categorical fields. */
+  includeValues?: boolean;
+  /** Cap on returned hits (post-ranking). */
+  limit?: number;
+}
+
+/** One ranked search result. */
+export interface FieldSearchHit {
+  object: string;
+  name: string;
+  label: string;
+  type: string;
+  /** Population density if discovery scored it, else undefined. */
+  populationPct?: number;
+  /** Whether the field is in the object's promoted (Tier 1) set. */
+  promoted: boolean;
+  /** The catalog's usefulness score (ADR-300 regulator total). */
+  score: number;
+  /** How strongly the term matched this field. Higher is a better match. */
+  relevance: number;
+  /** Which metadata carried the match: any of 'name', 'label', 'helpText'. */
+  matchedOn: string[];
+  /** Active picklist values, when requested and the field is categorical. */
+  values?: string[];
+}
+
+/** Default and ceiling on returned hits — a search surface, not a dump. */
+export const DEFAULT_SEARCH_LIMIT = 25;
+export const MAX_SEARCH_LIMIT = 100;
+
+/** Escape a user token so it can sit inside a RegExp safely. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** True if `token` appears as a whole word in `text` (word-boundary match). */
+function matchesWord(text: string, token: string): boolean {
+  return new RegExp(`\\b${escapeRegExp(token)}\\b`).test(text);
+}
+
+/**
+ * Score how well a single field matches the search tokens.
+ *
+ * The weighting encodes a preference order: a token that *is* a segment of the
+ * API name ("ai" in `ai_opportunity__c`) is a stronger signal than the same
+ * token buried inside a longer word ("ai" in `email`), and a name match beats a
+ * label match beats a help-text match. Name and label contributions are summed
+ * rather than max'd — a term landing in both is genuinely more relevant than
+ * one landing in either alone.
+ *
+ * Returns null when no token matched anywhere; such a field is not a hit.
+ */
+export function scoreFieldMatch(
+  tokens: string[],
+  field: { name: string; label: string; helpText: string | null },
+): { relevance: number; matchedOn: string[] } | null {
+  const nameL = field.name.toLowerCase();
+  const labelL = (field.label ?? '').toLowerCase();
+  const helpL = (field.helpText ?? '').toLowerCase();
+  // API-name segments: `ai_opportunity__c` -> ['ai', 'opportunity', 'c'].
+  const segments = nameL.split(/_+/).filter(Boolean);
+
+  let relevance = 0;
+  let matchedTokens = 0;
+  const matchedOn = new Set<string>();
+
+  for (const token of tokens) {
+    let tokenScore = 0;
+
+    // Name signal — strongest when the token is a discrete name segment.
+    if (segments.includes(token)) {
+      tokenScore += 50;
+      matchedOn.add('name');
+    } else if (segments.some(seg => seg.startsWith(token))) {
+      tokenScore += 30;
+      matchedOn.add('name');
+    } else if (nameL.includes(token)) {
+      tokenScore += 15;
+      matchedOn.add('name');
+    }
+
+    // Label signal — whole-word beats a substring buried in a longer word.
+    if (matchesWord(labelL, token)) {
+      tokenScore += 40;
+      matchedOn.add('label');
+    } else if (labelL.includes(token)) {
+      tokenScore += 12;
+      matchedOn.add('label');
+    }
+
+    // Help-text signal — weakest, but it disambiguates cryptic API names.
+    if (helpL.includes(token)) {
+      tokenScore += 8;
+      matchedOn.add('helpText');
+    }
+
+    if (tokenScore > 0) {
+      matchedTokens += 1;
+      relevance += tokenScore;
+    }
+  }
+
+  if (matchedTokens === 0) return null;
+
+  // Reward matching more of a multi-word query. A field hitting every token is
+  // a better answer than one that caught a single common word.
+  const coverage = matchedTokens / tokens.length;
+  relevance = Math.round(relevance * (0.5 + 0.5 * coverage));
+
+  return { relevance, matchedOn: [...matchedOn] };
+}
+
+/** Extract active picklist values from a scored field, if any. */
+function picklistValues(field: ScoredField): string[] | undefined {
+  const values = field.field.picklistValues;
+  return values && values.length > 0 ? values : undefined;
+}
+
+/**
+ * Rank discovered fields against a free-text term.
+ *
+ * Pure: the caller supplies every field to consider (typically the union of the
+ * cached catalogs) and this returns the ranked matches. Sort is by relevance,
+ * then the catalog's own usefulness score, then population, then name — so the
+ * order is stable and a well-populated field wins ties against an abandoned one.
+ */
+export function searchFields(
+  term: string,
+  candidates: FieldSearchInput[],
+  opts: FieldSearchOptions = {},
+): FieldSearchHit[] {
+  const tokens = term.toLowerCase().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return [];
+
+  const limit = Math.min(opts.limit ?? DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT);
+
+  const hits: FieldSearchHit[] = [];
+  for (const { objectName, field } of candidates) {
+    const pop = field.field.populationPct;
+    if (opts.minPopulationPct !== undefined && (pop ?? 0) < opts.minPopulationPct) {
+      continue;
+    }
+
+    const match = scoreFieldMatch(tokens, field.field);
+    if (!match) continue;
+
+    hits.push({
+      object: objectName,
+      name: field.field.name,
+      label: field.field.label,
+      type: field.field.type,
+      populationPct: pop,
+      promoted: field.promoted,
+      score: field.score,
+      relevance: match.relevance,
+      matchedOn: match.matchedOn,
+      ...(opts.includeValues ? { values: picklistValues(field) } : {}),
+    });
+  }
+
+  hits.sort((a, b) =>
+    b.relevance - a.relevance ||
+    b.score - a.score ||
+    (b.populationPct ?? 0) - (a.populationPct ?? 0) ||
+    a.name.localeCompare(b.name),
+  );
+
+  return hits.slice(0, limit);
+}


### PR DESCRIPTION
## Why

Field discovery (ADR-300) answers *"which fields on this object matter?"* It doesn't answer the question that comes first in practice: **"I know what I want to query but not the API name — which field is it?"**

The catalog is organised by object, so resolving a concept means pulling `salesforce://field-catalog/{Object}/all` and scanning it. In Claude Code that scan is a local `grep`; in a plain chat client (Claude Desktop) there's no local text-processing escape hatch, so the agent reads an 80KB JSON blob into context and eyeballs it — and the field is often a 3–4% populated custom flag that's easy to skim past.

This came out of a real session: a user asked for pipeline "attributed to AI" without knowing the field name. Resolving it took *(1)* read the full catalog, *(2)* grep for `ai` → `AI_Opportunity__c` + `AI_Delivery__c`, *(3)* run a `GROUP BY` **just to learn the values were `Yes`/`No`**, then *(4)* aggregate. Steps 1–3 are pure discovery overhead that recurs for every "which field is X" question.

## What

A `search_fields` tool — a **lexical** search over the already-discovered catalogs. Read-only over cached metadata; no new Salesforce calls on the hot path.

```jsonc
{ "term": "ai", "objectName": "Opportunity", "includeValues": true }
```

- **Ranked match** across field API name, label, and help text. Signal hierarchy: name-segment (`ai` in `ai_opportunity__c`) > substring (`ai` in `email`); name > label > help text; multi-word queries scaled by token coverage; deterministic tie-break (relevance → catalog score → population → name).
- **`includeValues`** returns active picklist values for matched fields, folding the step-3 round-trip into the search — so the agent writes `WHERE AI_Opportunity__c = 'Yes'` directly. Values ride along on the describe discovery already fetches (zero extra API cost).
- **Scope**: all core objects by default; `objectName` narrows and discovers on demand. `minPopulationPct` off by default — sparse custom flags are the point. `limit` defaults 25, capped 100.

## What it deliberately is *not*

- **Not semantic.** It matches strings in metadata — finds `AI_Opportunity__c` from "ai", not from "attribution". The empty-result message says so and points at the full catalog. Synonym/embedding matching is left as a future `mode`.
- **Not a free-text value sampler.** `includeValues` returns picklist sets only (free); live sampling belongs behind its own guard rail (cf. ADR-301).
- **Not an "answer this business question" tool.** It resolves concept → field and stops; the judgement calls (which amount field, date bounds, dedupe overlapping flags) stay with the caller, explicit and auditable.

## Changes

- `src/utils/field-search.ts` — pure, unit-tested matcher
- `src/handlers/field-search-handler.ts` — catalog gather, on-demand scoping, honest empty paths
- `FieldCandidate.picklistValues` + `FieldDiscovery.allCatalogs()` — additive discovery hooks (catalog resource output unchanged)
- schema + wiring + README; **ADR-302**
- **+17 tests; full suite 496 passing, lint + build clean**

## Verification

Built branch driven against the live org over stdio: tool is registered in the real server's `ListTools`, handler executes and degrades gracefully. The auth-gated *successful-match* path couldn't be driven headless (extension creds are encrypted at rest, decrypted only by the Desktop app) — it's covered by the handler unit test, which renders the real AI fields + `Yes, No` values. Confirm live by pointing the extension at this branch's `build/`.
