### PR TITLE
Score fields from a recency-weighted sample, and report drift (ADR-301)

### DIFF
--- a/src/__tests__/field-discovery.test.ts
+++ b/src/__tests__/field-discovery.test.ts
@@ -3,7 +3,7 @@
 import { FieldDiscovery } from '../client/field-discovery';
 import { SalesforceClient } from '../client/salesforce-client';
 import { Regulator } from '../utils/field-regulator';
-import { CORE_OBJECTS, MAX_PROMOTED_PER_OBJECT, MAX_PROMOTED_TOTAL } from '../utils/discovery-constants';
+import { CORE_OBJECTS, MAX_PROMOTED_PER_OBJECT, MAX_PROMOTED_TOTAL, SAMPLE_STRATA } from '../utils/discovery-constants';
 
 // ── Fixtures ─────────────────────────────────────────────────────────
 
@@ -27,23 +27,26 @@ function field(overrides: Partial<FakeField> & { name: string }): FakeField {
   };
 }
 
+export type FakeRecord = Record<string, unknown> & { CreatedDate: string };
+
 /**
- * Build a fake SalesforceClient. `describes` maps object name to its field
- * list; `counts` maps object name to total record count. Per-field population
- * counts come from `populated` (object name -> field name -> count).
+ * Build a fake Salesforce that holds records and answers the two query shapes
+ * discovery actually issues (ADR-301): one aggregate probe for count and span,
+ * then a windowed wide SELECT per stratum.
+ *
+ * It simulates rows rather than mocking query strings, because the thing under
+ * test is what the sampler reads *out of records* — how a boolean splits, how
+ * usage moves across creation time. A fake that returned canned counts could
+ * only ever confirm the arithmetic it was handed.
  */
 function makeClient(opts: {
   describes?: Record<string, FakeField[]>;
-  counts?: Record<string, number>;
-  populated?: Record<string, Record<string, number>>;
+  records?: Record<string, FakeRecord[]>;
   describeError?: Record<string, string>;
-  countError?: string[];
-  fieldQueryError?: string[];
+  probeError?: string[];
+  sampleError?: string[];
 } = {}) {
-  const {
-    describes = {}, counts = {}, populated = {},
-    describeError = {}, countError = [], fieldQueryError = [],
-  } = opts;
+  const { describes = {}, records = {}, describeError = {}, probeError = [], sampleError = [] } = opts;
 
   const describe = jest.fn(async (objectName: string) => {
     if (describeError[objectName]) throw new Error(describeError[objectName]);
@@ -51,20 +54,36 @@ function makeClient(opts: {
   });
 
   const query = jest.fn(async (soql: string) => {
-    const fromMatch = soql.match(/FROM (\w+)/);
-    const objectName = fromMatch ? fromMatch[1] : '';
+    const objectName = soql.match(/FROM (\w+)/)?.[1] ?? '';
+    const rows = records[objectName] ?? [];
 
-    // Total record count: SELECT COUNT() FROM X
-    if (/SELECT COUNT\(\)/.test(soql)) {
-      if (countError.includes(objectName)) throw new Error('count blew up');
-      return { totalSize: counts[objectName] ?? 0 };
+    // Probe: SELECT COUNT(Id) total, MIN(CreatedDate) spanFrom, MAX(CreatedDate) spanTo
+    if (/MIN\(CreatedDate\)/.test(soql)) {
+      if (probeError.includes(objectName)) throw new Error('probe blew up');
+      if (rows.length === 0) return { records: [{ total: 0, spanFrom: null, spanTo: null }] };
+      const dates = rows.map(r => r.CreatedDate).sort();
+      return { records: [{ total: rows.length, spanFrom: dates[0], spanTo: dates[dates.length - 1] }] };
     }
 
-    // Per-field population: SELECT COUNT(Id) cnt FROM X WHERE f != null
-    const fieldMatch = soql.match(/WHERE (\w+) != null/);
-    const fieldName = fieldMatch ? fieldMatch[1] : '';
-    if (fieldQueryError.includes(fieldName)) throw new Error('field query blew up');
-    return { records: [{ cnt: populated[objectName]?.[fieldName] ?? 0 }] };
+    // Stratum: SELECT <fields> FROM X WHERE CreatedDate >= A [AND CreatedDate < B] LIMIT n
+    if (sampleError.includes(objectName)) throw new Error('sample blew up');
+    const from = soql.match(/CreatedDate >= ([0-9TZ:.-]+)/)?.[1];
+    const to = soql.match(/CreatedDate < ([0-9TZ:.-]+)/)?.[1];
+    const limit = Number(soql.match(/LIMIT (\d+)/)?.[1] ?? rows.length);
+    const projected = (soql.match(/^SELECT (.+?) FROM/)?.[1] ?? '').split(', ');
+
+    const inWindow = rows.filter(r => {
+      const t = Date.parse(r.CreatedDate);
+      if (from !== undefined && t < Date.parse(from)) return false;
+      if (to !== undefined && t >= Date.parse(to)) return false;
+      return true;
+    }).slice(0, limit);
+
+    // Salesforce returns only what was asked for.
+    return {
+      records: inWindow.map(r =>
+        Object.fromEntries(projected.filter(f => f in r).map(f => [f, r[f]]))),
+    };
   });
 
   const client = {
@@ -73,6 +92,21 @@ function makeClient(opts: {
   };
 
   return { client: client as unknown as SalesforceClient, describe, query };
+}
+
+/** N records spread evenly across a span, each built by `shape(i, n)`. */
+function spread(
+  n: number,
+  shape: (i: number, n: number) => Record<string, unknown>,
+  fromISO = '2016-01-01T00:00:00Z',
+  toISO = '2026-01-01T00:00:00Z',
+): FakeRecord[] {
+  const lo = Date.parse(fromISO);
+  const hi = Date.parse(toISO);
+  return Array.from({ length: n }, (_, i) => ({
+    ...shape(i, n),
+    CreatedDate: new Date(lo + ((hi - lo) * i) / Math.max(1, n - 1)).toISOString(),
+  }));
 }
 
 // Discovery logs progress to stderr; keep test output clean.
@@ -87,8 +121,7 @@ describe('FieldDiscovery', () => {
     it('describes an object and returns its catalog', async () => {
       const { client, describe } = makeClient({
         describes: { Account: [field({ name: 'Name' }), field({ name: 'Industry' })] },
-        counts: { Account: 100 },
-        populated: { Account: { Name: 100, Industry: 50 } },
+        records: { Account: spread(100, () => ({ Name: 'x', Industry: 'Tech' })) },
       });
       const discovery = new FieldDiscovery(client);
 
@@ -104,8 +137,10 @@ describe('FieldDiscovery', () => {
     it('scores fields by population density', async () => {
       const { client } = makeClient({
         describes: { Account: [field({ name: 'Name' }), field({ name: 'Industry' })] },
-        counts: { Account: 200 },
-        populated: { Account: { Name: 200, Industry: 50 } },
+        // Name always filled; Industry on a quarter of records, evenly across time.
+        records: {
+          Account: spread(200, i => ({ Name: 'x', Industry: i % 4 === 0 ? 'Tech' : null })),
+        },
       });
       const discovery = new FieldDiscovery(client);
 
@@ -118,10 +153,44 @@ describe('FieldDiscovery', () => {
       expect(catalog!.fields[0].field.name).toBe('Name');
     });
 
+    // The whole point of sampling: cost scales with strata, not with fields.
+    it('costs a query per stratum, not a query per field', async () => {
+      const many = Array.from({ length: 60 }, (_, i) => field({ name: `F${i}` }));
+      const { client, query } = makeClient({
+        describes: { Account: many },
+        records: { Account: spread(500, () => Object.fromEntries(many.map(f => [f.name, 'x']))) },
+      });
+      const discovery = new FieldDiscovery(client);
+
+      await discovery.discoverObject('Account');
+
+      // One probe + one per stratum. The old design would have issued ~62.
+      expect(query).toHaveBeenCalledTimes(1 + SAMPLE_STRATA);
+    });
+
+    it('reads every field from a single projection per stratum', async () => {
+      const { client, query } = makeClient({
+        describes: { Account: [field({ name: 'Name' }), field({ name: 'Industry' })] },
+        records: { Account: spread(50, () => ({ Name: 'x', Industry: 'y' })) },
+      });
+      const discovery = new FieldDiscovery(client);
+
+      await discovery.discoverObject('Account');
+
+      const sampleQueries = query.mock.calls
+        .map(([soql]) => soql as string)
+        .filter(s => /CreatedDate >=/.test(s));
+      expect(sampleQueries.length).toBeGreaterThan(0);
+      for (const soql of sampleQueries) {
+        expect(soql).toContain('Name');
+        expect(soql).toContain('Industry');
+      }
+    });
+
     it('caches the catalog — a second call does not re-describe', async () => {
       const { client, describe } = makeClient({
         describes: { Account: [field({ name: 'Name' })] },
-        counts: { Account: 10 },
+        records: { Account: spread(10, () => ({ Name: 'x' })) },
       });
       const discovery = new FieldDiscovery(client);
 
@@ -142,25 +211,27 @@ describe('FieldDiscovery', () => {
       expect(discovery.getStats().errors).toContain('Ghost: no such object');
     });
 
-    it('skips population scoring entirely when the object has no records', async () => {
+    it('skips sampling entirely when the object has no records', async () => {
       const { client, query } = makeClient({
         describes: { Account: [field({ name: 'Name' })] },
-        counts: { Account: 0 },
+        records: { Account: [] },
       });
       const discovery = new FieldDiscovery(client);
 
       const catalog = await discovery.discoverObject('Account');
 
       expect(catalog!.totalRecords).toBe(0);
-      // Only the COUNT() probe runs — no per-field queries.
+      expect(catalog!.sampledRecords).toBe(0);
+      // Only the probe runs — nothing to sample.
       expect(query).toHaveBeenCalledTimes(1);
       expect(catalog!.fields[0].field.populationPct).toBeUndefined();
     });
 
-    it('survives a failing COUNT and still returns a catalog', async () => {
+    it('survives a failing probe and still returns a catalog', async () => {
       const { client } = makeClient({
         describes: { Account: [field({ name: 'Name' })] },
-        countError: ['Account'],
+        records: { Account: spread(10, () => ({ Name: 'x' })) },
+        probeError: ['Account'],
       });
       const discovery = new FieldDiscovery(client);
 
@@ -168,28 +239,27 @@ describe('FieldDiscovery', () => {
 
       expect(catalog).not.toBeNull();
       expect(catalog!.totalRecords).toBe(0);
-      expect(discovery.getStats().errors).toContain('Account COUNT: count blew up');
+      expect(discovery.getStats().errors).toContain('Account sample probe: probe blew up');
     });
 
-    it('leaves a field unscored when its population query fails, without failing discovery', async () => {
+    it('leaves fields unscored when every sample window fails, without failing discovery', async () => {
       const { client } = makeClient({
-        describes: { Account: [field({ name: 'Name' }), field({ name: 'Broken' })] },
-        counts: { Account: 100 },
-        populated: { Account: { Name: 100 } },
-        fieldQueryError: ['Broken'],
+        describes: { Account: [field({ name: 'Name' })] },
+        records: { Account: spread(100, () => ({ Name: 'x' })) },
+        sampleError: ['Account'],
       });
       const discovery = new FieldDiscovery(client);
 
       const catalog = await discovery.discoverObject('Account');
 
-      const broken = catalog!.fields.find(s => s.field.name === 'Broken')!;
-      const name = catalog!.fields.find(s => s.field.name === 'Name')!;
-      expect(broken.field.populationPct).toBeUndefined();
-      expect(name.field.populationPct).toBe(100);
+      expect(catalog).not.toBeNull();
+      expect(catalog!.sampledRecords).toBe(0);
+      expect(catalog!.fields[0].field.populationPct).toBeUndefined();
+      expect(discovery.getStats().errors.some(e => /stratum/.test(e))).toBe(true);
     });
 
     it('does not score non-scorable field types', async () => {
-      const { client, query } = makeClient({
+      const { client } = makeClient({
         describes: {
           Account: [
             field({ name: 'Id', type: 'id' }),              // identifier — not scorable
@@ -197,38 +267,92 @@ describe('FieldDiscovery', () => {
             field({ name: 'Name', type: 'string' }),         // scorable
           ],
         },
-        counts: { Account: 50 },
-        populated: { Account: { Name: 25 } },
+        records: { Account: spread(50, () => ({ Id: '1', Notes: 'n', Name: 'x' })) },
+      });
+      const discovery = new FieldDiscovery(client);
+
+      const catalog = await discovery.discoverObject('Account');
+
+      const pop = (n: string) => catalog!.fields.find(s => s.field.name === n)!.field.populationPct;
+      expect(pop('Name')).toBe(100);
+      expect(pop('Id')).toBeUndefined();
+      expect(pop('Notes')).toBeUndefined();
+    });
+
+    // SOQL rejects these in a wide projection, so they must not be asked for.
+    it('leaves compound and long-text fields out of the projection', async () => {
+      const { client, query } = makeClient({
+        describes: {
+          Account: [
+            field({ name: 'BillingAddress', type: 'address' }),
+            field({ name: 'Notes', type: 'textarea' }),
+            field({ name: 'Name', type: 'string' }),
+          ],
+        },
+        records: { Account: spread(20, () => ({ Name: 'x' })) },
       });
       const discovery = new FieldDiscovery(client);
 
       await discovery.discoverObject('Account');
 
-      const scored = query.mock.calls
-        .map(([soql]) => (soql as string).match(/WHERE (\w+) != null/)?.[1])
-        .filter(Boolean);
-      expect(scored).toEqual(['Name']);
+      const sample = query.mock.calls.map(([s]) => s as string).find(s => /CreatedDate >=/.test(s))!;
+      expect(sample).toContain('Name');
+      expect(sample).not.toContain('BillingAddress');
+      expect(sample).not.toContain('Notes');
     });
 
     it('does not score non-nillable fields', async () => {
-      const { client, query } = makeClient({
+      const { client } = makeClient({
         describes: {
           Account: [
             field({ name: 'Required', nillable: false }),
             field({ name: 'Optional', nillable: true }),
           ],
         },
-        counts: { Account: 10 },
-        populated: { Account: { Optional: 5 } },
+        records: { Account: spread(10, i => ({ Required: 'x', Optional: i % 2 ? 'y' : null })) },
       });
       const discovery = new FieldDiscovery(client);
 
-      await discovery.discoverObject('Account');
+      const catalog = await discovery.discoverObject('Account');
 
-      const scored = query.mock.calls
-        .map(([soql]) => (soql as string).match(/WHERE (\w+) != null/)?.[1])
-        .filter(Boolean);
-      expect(scored).toEqual(['Optional']);
+      const pop = (n: string) => catalog!.fields.find(s => s.field.name === n)!.field.populationPct;
+      // Required is 100% populated by definition — a fact about the schema, not
+      // about use, so it carries no signal and stays unscored (ADR-300).
+      expect(pop('Required')).toBeUndefined();
+      expect(pop('Optional')).toBeDefined();
+    });
+
+    // A checkbox is never null, so null-counting scores every checkbox 100%.
+    // How it splits is the real evidence, and only a sample can see it.
+    it('scores a boolean by how often it is true', async () => {
+      const { client } = makeClient({
+        describes: {
+          Account: [
+            field({ name: 'Used__c', type: 'boolean', nillable: false }),
+            field({ name: 'Dead__c', type: 'boolean', nillable: false }),
+          ],
+        },
+        records: { Account: spread(100, i => ({ Used__c: i % 4 === 0, Dead__c: false })) },
+      });
+      const discovery = new FieldDiscovery(client);
+
+      const catalog = await discovery.discoverObject('Account');
+
+      const pop = (n: string) => catalog!.fields.find(s => s.field.name === n)!.field.populationPct;
+      expect(pop('Used__c')).toBe(25);
+      expect(pop('Dead__c')).toBe(0);
+    });
+
+    it('does not promote an all-false checkbox', async () => {
+      const { client } = makeClient({
+        describes: { Account: [field({ name: 'Dead__c', type: 'boolean', nillable: false })] },
+        records: { Account: spread(100, () => ({ Dead__c: false })) },
+      });
+      const discovery = new FieldDiscovery(client);
+
+      const catalog = await discovery.discoverObject('Account');
+
+      expect(catalog!.promoted.map(s => s.field.name)).not.toContain('Dead__c');
     });
 
     it('honors injected regulators over the defaults', async () => {
@@ -236,8 +360,7 @@ describe('FieldDiscovery', () => {
         f.name === 'Industry' ? { regulator: 'test', delta: 999, reason: 'test boost' } : null;
       const { client } = makeClient({
         describes: { Account: [field({ name: 'Name' }), field({ name: 'Industry' })] },
-        counts: { Account: 100 },
-        populated: { Account: { Name: 100, Industry: 1 } },
+        records: { Account: spread(100, i => ({ Name: 'x', Industry: i === 0 ? 'Tech' : null })) },
       });
       const discovery = new FieldDiscovery(client, [onlyBoostIndustry]);
 
@@ -261,7 +384,7 @@ describe('FieldDiscovery', () => {
     it('returns the catalog once discovered', async () => {
       const { client } = makeClient({
         describes: { Account: [field({ name: 'Name' })] },
-        counts: { Account: 1 },
+        records: { Account: spread(1, () => ({ Name: 'x' })) },
       });
       const discovery = new FieldDiscovery(client);
       await discovery.discoverObject('Account');
@@ -279,7 +402,7 @@ describe('FieldDiscovery', () => {
             field({ name: 'Title', label: 'Title', type: 'string' }),
           ],
         },
-        counts: { ContentVersion: 10 },
+        records: { ContentVersion: spread(10, () => ({ IsLatest__c: true, Title: 't', LatestNote: 'n' })) },
       });
       const discovery = new FieldDiscovery(client);
       await discovery.discoverObject('ContentVersion');
@@ -292,7 +415,7 @@ describe('FieldDiscovery', () => {
         describes: {
           ContentVersion: [field({ name: 'LatestNote', label: 'Latest Version Note', type: 'string' })],
         },
-        counts: { ContentVersion: 10 },
+        records: { ContentVersion: spread(10, () => ({ IsLatest__c: true, Title: 't', LatestNote: 'n' })) },
       });
       const discovery = new FieldDiscovery(client);
       await discovery.discoverObject('ContentVersion');
@@ -310,7 +433,7 @@ describe('FieldDiscovery', () => {
     it('returns undefined for an unknown semantic name', async () => {
       const { client } = makeClient({
         describes: { ContentVersion: [field({ name: 'Title', type: 'string' })] },
-        counts: { ContentVersion: 1 },
+        records: { ContentVersion: spread(1, () => ({ Title: 't' })) },
       });
       const discovery = new FieldDiscovery(client);
       await discovery.discoverObject('ContentVersion');
@@ -320,11 +443,62 @@ describe('FieldDiscovery', () => {
   });
 
   describe('getStats', () => {
+    // Progress, not a bare "not ready": a caller deciding whether to wait or
+    // fall back needs to know how much is outstanding (ADR-301).
+    describe('pending state', () => {
+      it('names the objects still outstanding before discovery runs', () => {
+        const { client } = makeClient();
+        const discovery = new FieldDiscovery(client);
+
+        const stats = discovery.getStats();
+
+        expect(stats.ready).toBe(false);
+        expect(stats.objectsExpected).toBe(CORE_OBJECTS.length);
+        expect(stats.pendingObjects).toEqual([...CORE_OBJECTS]);
+      });
+
+      it('shrinks the pending list as objects land', async () => {
+        const { client } = makeClient({
+          describes: { Account: [field({ name: 'Name' })] },
+          records: { Account: spread(10, () => ({ Name: 'x' })) },
+        });
+        const discovery = new FieldDiscovery(client);
+
+        await discovery.discoverObject('Account');
+
+        expect(discovery.getStats().pendingObjects).not.toContain('Account');
+        expect(discovery.getStats().pendingObjects).toContain('Contact');
+      });
+
+      it('reports nothing pending once discovery is ready', async () => {
+        const { client } = makeClient({
+          describes: Object.fromEntries(CORE_OBJECTS.map(o => [o, [field({ name: 'Name' })]])),
+          records: Object.fromEntries(CORE_OBJECTS.map(o => [o, spread(5, () => ({ Name: 'x' }))])),
+        });
+        const discovery = new FieldDiscovery(client);
+
+        discovery.startAsync();
+        await discovery.whenSettled();
+
+        expect(discovery.getStats().pendingObjects).toEqual([]);
+        expect(discovery.getStats().etaMs).toBeUndefined();
+      });
+
+      // An estimate needs something to estimate from; guessing before any
+      // object has landed would be inventing a number.
+      it('offers no estimate before there is any pace to project from', () => {
+        const { client } = makeClient();
+        const discovery = new FieldDiscovery(client);
+
+        expect(discovery.getStats().etaMs).toBeUndefined();
+      });
+    });
+
     it('reports zeroed, not-ready stats before discovery runs', () => {
       const { client } = makeClient();
       const discovery = new FieldDiscovery(client);
 
-      expect(discovery.getStats()).toEqual({
+      expect(discovery.getStats()).toMatchObject({
         objectsDiscovered: 0,
         totalFieldsSeen: 0,
         totalPromoted: 0,
@@ -340,8 +514,10 @@ describe('FieldDiscovery', () => {
           Account: [field({ name: 'Name' }), field({ name: 'Industry' })],
           Contact: [field({ name: 'Email' })],
         },
-        counts: { Account: 10, Contact: 10 },
-        populated: { Account: { Name: 10, Industry: 10 }, Contact: { Email: 10 } },
+        records: {
+          Account: spread(10, () => ({ Name: 'x', Industry: 'Tech' })),
+          Contact: spread(10, () => ({ Email: 'a@b.c' })),
+        },
       });
       const discovery = new FieldDiscovery(client);
       await discovery.discoverObject('Account');
@@ -367,12 +543,12 @@ describe('FieldDiscovery', () => {
   describe('startAsync', () => {
     it('discovers every core object and flips ready', async () => {
       const describes: Record<string, FakeField[]> = {};
-      const counts: Record<string, number> = {};
+      const records: Record<string, FakeRecord[]> = {};
       for (const obj of CORE_OBJECTS) {
         describes[obj] = [field({ name: 'Name' })];
-        counts[obj] = 5;
+        records[obj] = spread(5, () => ({ Name: 'x' }));
       }
-      const { client } = makeClient({ describes, counts });
+      const { client } = makeClient({ describes, records });
       const discovery = new FieldDiscovery(client);
 
       expect(discovery.ready).toBe(false);
@@ -389,7 +565,7 @@ describe('FieldDiscovery', () => {
     it('is idempotent — a second call does not start a second pass', async () => {
       const { client, describe } = makeClient({
         describes: Object.fromEntries(CORE_OBJECTS.map(o => [o, [field({ name: 'Name' })]])),
-        counts: Object.fromEntries(CORE_OBJECTS.map(o => [o, 1])),
+        records: Object.fromEntries(CORE_OBJECTS.map(o => [o, spread(1, () => ({ Name: 'x' }))])),
       });
       const discovery = new FieldDiscovery(client);
 
@@ -406,7 +582,7 @@ describe('FieldDiscovery', () => {
       const describes = Object.fromEntries(CORE_OBJECTS.map(o => [o, [field({ name: 'Name' })]]));
       const { client } = makeClient({
         describes,
-        counts: Object.fromEntries(CORE_OBJECTS.map(o => [o, 1])),
+        records: Object.fromEntries(CORE_OBJECTS.map(o => [o, spread(1, () => ({ Name: 'x' }))])),
         describeError: { [CORE_OBJECTS[0]]: 'permission denied' },
       });
       const discovery = new FieldDiscovery(client);
@@ -425,7 +601,7 @@ describe('FieldDiscovery', () => {
     it('resolves once startup discovery has finished', async () => {
       const { client } = makeClient({
         describes: Object.fromEntries(CORE_OBJECTS.map(o => [o, [field({ name: 'Name' })]])),
-        counts: Object.fromEntries(CORE_OBJECTS.map(o => [o, 1])),
+        records: Object.fromEntries(CORE_OBJECTS.map(o => [o, spread(1, () => ({ Name: 'x' }))])),
       });
       const discovery = new FieldDiscovery(client);
 
@@ -459,6 +635,92 @@ describe('FieldDiscovery', () => {
     });
   });
 
+  // The motivating case, in miniature. On a real org BillingCity is 98%
+  // populated in the oldest records and 3% in the newest — an all-time count
+  // averages that to a middling number describing no record that ever existed,
+  // and ranks the corpse alongside a genuinely steady field.
+  describe('drift across creation time', () => {
+    const abandonedThenSteady = () => makeClient({
+      describes: {
+        Account: [
+          field({ name: 'Abandoned__c', custom: true }),
+          field({ name: 'Steady__c', custom: true }),
+        ],
+      },
+      records: {
+        Account: spread(300, (i, n) => ({
+          // Filled for the first two-thirds of the object's life, then dropped.
+          Abandoned__c: i < n * 0.66 ? 'filled' : null,
+          // Filled throughout.
+          Steady__c: 'filled',
+        })),
+      },
+    });
+
+    it('reports the per-era populations a single number cannot show', async () => {
+      const { client } = abandonedThenSteady();
+      const discovery = new FieldDiscovery(client);
+
+      const catalog = await discovery.discoverObject('Account');
+
+      const strata = catalog!.fields.find(s => s.field.name === 'Abandoned__c')!.field.strataPopulation!;
+      expect(strata.length).toBeGreaterThan(1);
+      expect(strata[0]).toBeGreaterThan(strata[strata.length - 1]);
+    });
+
+    it('marks a collapsing field as falling and a steady one as stable', async () => {
+      const { client } = abandonedThenSteady();
+      const discovery = new FieldDiscovery(client);
+
+      const catalog = await discovery.discoverObject('Account');
+      const trend = (n: string) => catalog!.fields.find(s => s.field.name === n)!.field.trend;
+
+      expect(trend('Abandoned__c')!.direction).toBe('falling');
+      expect(trend('Steady__c')!.direction).toBe('stable');
+    });
+
+    it('ranks the abandoned field below the steady one', async () => {
+      const { client } = abandonedThenSteady();
+      const discovery = new FieldDiscovery(client);
+
+      const catalog = await discovery.discoverObject('Account');
+      const score = (n: string) => catalog!.fields.find(s => s.field.name === n)!.score;
+
+      expect(score('Abandoned__c')).toBeLessThan(score('Steady__c'));
+      expect(catalog!.fields[0].field.name).toBe('Steady__c');
+    });
+
+    it('records the drift demotion in the audit trail', async () => {
+      const { client } = abandonedThenSteady();
+      const discovery = new FieldDiscovery(client);
+
+      const catalog = await discovery.discoverObject('Account');
+      const adjustments = catalog!.fields.find(s => s.field.name === 'Abandoned__c')!.adjustments;
+
+      expect(adjustments.some(a => a.regulator === 'drift')).toBe(true);
+    });
+
+    // The tail is what makes recency weighting safe: a field alive only in old
+    // records must still be visible, or an agent querying history never learns
+    // it exists.
+    it('still finds a field that only the oldest records populate', async () => {
+      const { client } = makeClient({
+        describes: { Account: [field({ name: 'Legacy__c', custom: true })] },
+        records: {
+          Account: spread(300, (i, n) => ({ Legacy__c: i < n * 0.15 ? 'filled' : null })),
+        },
+      });
+      const discovery = new FieldDiscovery(client);
+
+      const catalog = await discovery.discoverObject('Account');
+      const legacy = catalog!.fields.find(s => s.field.name === 'Legacy__c')!;
+
+      // Seen, and honestly described as falling — not silently scored zero.
+      expect(legacy.field.populationPct).toBeGreaterThan(0);
+      expect(legacy.field.strataPopulation![0]).toBeGreaterThan(0);
+    });
+  });
+
   describe('global promotion budget', () => {
     it('caps promoted fields at the per-object maximum', async () => {
       const many = Array.from({ length: MAX_PROMOTED_PER_OBJECT + 20 }, (_, i) =>
@@ -466,9 +728,8 @@ describe('FieldDiscovery', () => {
       );
       const { client } = makeClient({
         describes: { Account: many },
-        counts: { Account: 100 },
         // Uniform population: no knee, so the hard per-object cap is what bites.
-        populated: { Account: Object.fromEntries(many.map(f => [f.name, 100])) },
+        records: { Account: spread(100, () => Object.fromEntries(many.map(f => [f.name, 'x']))) },
       });
       const discovery = new FieldDiscovery(client);
 
@@ -480,17 +741,15 @@ describe('FieldDiscovery', () => {
     it('demotes the lowest-scoring fields once the global budget is exceeded', async () => {
       // 6 core objects x 40 promoted = 240, over the 200 global budget.
       const describes: Record<string, FakeField[]> = {};
-      const counts: Record<string, number> = {};
-      const populated: Record<string, Record<string, number>> = {};
+      const records: Record<string, FakeRecord[]> = {};
       for (const obj of CORE_OBJECTS) {
         const fields = Array.from({ length: MAX_PROMOTED_PER_OBJECT + 10 }, (_, i) =>
           field({ name: `${obj}_F${i}` }),
         );
         describes[obj] = fields;
-        counts[obj] = 100;
-        populated[obj] = Object.fromEntries(fields.map(f => [f.name, 100]));
+        records[obj] = spread(100, () => Object.fromEntries(fields.map(f => [f.name, 'x'])));
       }
-      const { client } = makeClient({ describes, counts, populated });
+      const { client } = makeClient({ describes, records });
       const discovery = new FieldDiscovery(client);
 
       discovery.startAsync();
@@ -508,10 +767,12 @@ describe('FieldDiscovery', () => {
       const contactFields = Array.from({ length: 30 }, (_, i) => field({ name: `C${i}` }));
       const { client } = makeClient({
         describes: { Account: accountFields, Contact: contactFields },
-        counts: { Account: 100, Contact: 100 },
-        populated: {
-          Account: Object.fromEntries(accountFields.map(f => [f.name, 100])),
-          Contact: Object.fromEntries(contactFields.map(f => [f.name, 5])),
+        records: {
+          Account: spread(100, () => Object.fromEntries(accountFields.map(f => [f.name, 'x']))),
+          // Sparse but not dead: ~5% of records, spread evenly so it reads as
+          // rare rather than abandoned.
+          Contact: spread(100, i =>
+            Object.fromEntries(contactFields.map(f => [f.name, i % 20 === 0 ? 'x' : null]))),
         },
       });
       const discovery = new FieldDiscovery(client);
@@ -528,8 +789,7 @@ describe('FieldDiscovery', () => {
     it('leaves promotions untouched when under the global budget', async () => {
       const { client } = makeClient({
         describes: { Account: [field({ name: 'Name' }), field({ name: 'Industry' })] },
-        counts: { Account: 100 },
-        populated: { Account: { Name: 100, Industry: 90 } },
+        records: { Account: spread(100, i => ({ Name: 'x', Industry: i % 10 ? 'Tech' : null })) },
       });
       const discovery = new FieldDiscovery(client);
 
@@ -544,7 +804,7 @@ describe('FieldDiscovery', () => {
     it('ensures the client is initialized before describing', async () => {
       const { client } = makeClient({
         describes: { Account: [field({ name: 'Name' })] },
-        counts: { Account: 1 },
+        records: { Account: spread(1, () => ({ Name: 'x' })) },
       });
       const discovery = new FieldDiscovery(client);
 

--- a/src/__tests__/field-hints.test.ts
+++ b/src/__tests__/field-hints.test.ts
@@ -32,6 +32,7 @@ function catalog(objectName: string, fieldNames: string[], totalFields?: number)
     scoringMs: 1,
     totalFields: totalFields ?? fieldNames.length,
     totalRecords: 100,
+    sampledRecords: 100,
   };
 }
 

--- a/src/__tests__/field-search-handler.test.ts
+++ b/src/__tests__/field-search-handler.test.ts
@@ -27,7 +27,7 @@ function catalog(objectName: string, fields: ScoredField[]): ObjectCatalog {
   return {
     objectName, fields, promoted: fields.filter(f => f.promoted),
     wellKnown: new Map(), describeMs: 0, scoringMs: 0,
-    totalFields: fields.length, totalRecords: 100,
+    totalFields: fields.length, totalRecords: 100, sampledRecords: 100,
   };
 }
 

--- a/src/__tests__/query-handlers.test.ts
+++ b/src/__tests__/query-handlers.test.ts
@@ -98,7 +98,7 @@ describe('Query Handlers', () => {
             score: 90, adjustments: [], promoted: true,
           }],
           wellKnown: new Map(),
-          describeMs: 1, scoringMs: 1, totalFields: 87, totalRecords: 100,
+          describeMs: 1, scoringMs: 1, totalFields: 87, totalRecords: 100, sampledRecords: 100,
         } : undefined,
       };
 

--- a/src/__tests__/record-sampler.test.ts
+++ b/src/__tests__/record-sampler.test.ts
@@ -1,0 +1,231 @@
+/// <reference types="jest" />
+
+import {
+  stratumWeights, planStrata, isPopulated, populationIn, pooledPopulation, trendFrom,
+} from '../utils/record-sampler';
+import {
+  SAMPLE_STRATA, MIN_STRATUM_SAMPLE, DRIFT_THRESHOLD_PP,
+} from '../utils/discovery-constants';
+
+const DAY = 24 * 60 * 60 * 1000;
+const T0 = Date.UTC(2016, 0, 1);
+const T1 = Date.UTC(2026, 0, 1);
+
+describe('stratumWeights', () => {
+  it('sums to one', () => {
+    const w = stratumWeights(6);
+    expect(w.reduce((a, b) => a + b, 0)).toBeCloseTo(1, 10);
+  });
+
+  it('increases monotonically toward the newest stratum', () => {
+    const w = stratumWeights(6);
+    for (let i = 1; i < w.length; i++) {
+      expect(w[i]).toBeGreaterThan(w[i - 1]);
+    }
+  });
+
+  it('never gives the oldest stratum zero weight — the tail is evidence', () => {
+    expect(stratumWeights(6)[0]).toBeGreaterThan(0);
+  });
+
+  it('is uniform when the ratio is 1', () => {
+    const w = stratumWeights(4, 1);
+    expect(w).toEqual([0.25, 0.25, 0.25, 0.25]);
+  });
+});
+
+describe('planStrata', () => {
+  it('covers the whole span with contiguous windows', () => {
+    const strata = planStrata(T0, T1);
+
+    expect(strata).toHaveLength(SAMPLE_STRATA);
+    expect(strata[0].from).toBe(T0);
+    for (let i = 1; i < strata.length; i++) {
+      expect(strata[i].from).toBe(strata[i - 1].to);
+    }
+  });
+
+  // Records created while discovery is running would otherwise fall outside the
+  // span that was measured a moment earlier.
+  it('leaves the newest window open-ended', () => {
+    const strata = planStrata(T0, T1);
+
+    expect(strata[strata.length - 1].to).toBeUndefined();
+    expect(strata.slice(0, -1).every(s => s.to !== undefined)).toBe(true);
+  });
+
+  it('samples the newest window most heavily', () => {
+    const strata = planStrata(T0, T1);
+    const limits = strata.map(s => s.limit);
+
+    expect(limits[limits.length - 1]).toBeGreaterThan(limits[0]);
+  });
+
+  // The mandatory tail: a stratum sampled at zero reports its fields as unused,
+  // which is indistinguishable from their not existing.
+  it('gives every window a non-zero sample at or above the floor', () => {
+    for (const s of planStrata(T0, T1)) {
+      expect(s.limit).toBeGreaterThanOrEqual(MIN_STRATUM_SAMPLE);
+    }
+  });
+
+  it('plans the same sample twice for the same span', () => {
+    expect(planStrata(T0, T1)).toEqual(planStrata(T0, T1));
+  });
+
+  describe('degenerate spans', () => {
+    it('collapses to a single window when every record shares a timestamp', () => {
+      const strata = planStrata(T0, T0);
+
+      expect(strata).toHaveLength(1);
+      expect(strata[0].to).toBeUndefined();
+    });
+
+    it('collapses when the span is inverted', () => {
+      expect(planStrata(T1, T0)).toHaveLength(1);
+    });
+
+    it('collapses when the span is not a number', () => {
+      expect(planStrata(NaN, T1)).toHaveLength(1);
+      expect(planStrata(T0, NaN)).toHaveLength(1);
+    });
+
+    it('still samples a collapsed window', () => {
+      expect(planStrata(T0, T0)[0].limit).toBeGreaterThan(0);
+    });
+  });
+
+  it('honours an explicit stratum count and total', () => {
+    const strata = planStrata(T0, T0 + 10 * DAY, { strata: 3, total: 90, minPerStratum: 1 });
+
+    expect(strata).toHaveLength(3);
+    expect(strata.reduce((a, s) => a + s.limit, 0)).toBeGreaterThan(0);
+  });
+});
+
+describe('isPopulated', () => {
+  it.each([
+    ['a value', 'x', true],
+    ['zero', 0, true],
+    ['false', false, true],
+    ['null', null, false],
+    ['undefined', undefined, false],
+    ['empty string', '', false],
+  ])('treats %s as populated=%s', (_label, value, expected) => {
+    expect(isPopulated(value)).toBe(expected);
+  });
+});
+
+describe('populationIn', () => {
+  it('measures how many records carry a value', () => {
+    const recs = [{ City: 'A' }, { City: null }, { City: 'B' }, { City: '' }];
+
+    expect(populationIn(recs, 'City', false)).toBe(50);
+  });
+
+  // A checkbox is never null, so null-counting scores every checkbox 100% — a
+  // fact about the schema, not about use.
+  it('measures a boolean by how often it is true, not by being non-null', () => {
+    const recs = [{ Flag: false }, { Flag: false }, { Flag: true }, { Flag: false }];
+
+    expect(populationIn(recs, 'Flag', true)).toBe(25);
+    // What null-counting would have said:
+    expect(populationIn(recs, 'Flag', false)).toBe(100);
+  });
+
+  it('reports an all-false checkbox as unused', () => {
+    const recs = [{ Flag: false }, { Flag: false }];
+
+    expect(populationIn(recs, 'Flag', true)).toBe(0);
+  });
+
+  it('returns zero for an empty sample rather than dividing by it', () => {
+    expect(populationIn([], 'City', false)).toBe(0);
+  });
+});
+
+describe('pooledPopulation', () => {
+  // The sample is allocated by recency weight, so pooling already weights the
+  // present more heavily. Averaging per-stratum figures would hand every era
+  // equal say and throw that away.
+  it('weights the present by pooling the recency-allocated sample', () => {
+    const older = Array.from({ length: 10 }, () => ({ City: 'filled' }));
+    const newer = Array.from({ length: 90 }, () => ({ City: null }));
+
+    // Unweighted average of the two strata would be 50%.
+    expect(pooledPopulation([older, newer], 'City', false)).toBe(10);
+  });
+
+  it('handles an empty sample', () => {
+    expect(pooledPopulation([[], []], 'City', false)).toBe(0);
+  });
+});
+
+describe('trendFrom', () => {
+  it('reports a collapsing field as falling', () => {
+    const trend = trendFrom([98, 97, 96, 19, 12, 3]);
+
+    expect(trend!.direction).toBe('falling');
+    expect(trend!.deltaPp).toBeLessThan(-DRIFT_THRESHOLD_PP);
+  });
+
+  it('reports a steady field as stable', () => {
+    const trend = trendFrom([93, 95, 94, 96, 95, 94]);
+
+    expect(trend!.direction).toBe('stable');
+    expect(Math.abs(trend!.deltaPp)).toBeLessThan(DRIFT_THRESHOLD_PP);
+  });
+
+  it('reports a field coming into use as rising', () => {
+    const trend = trendFrom([0, 2, 5, 60, 80, 95]);
+
+    expect(trend!.direction).toBe('rising');
+    expect(trend!.deltaPp).toBeGreaterThan(DRIFT_THRESHOLD_PP);
+  });
+
+  it('is flat for a field that never moves', () => {
+    expect(trendFrom([80, 80, 80, 80, 80, 80])!.deltaPp).toBe(0);
+  });
+
+  // These are real shapes, measured on a production org. Both were misread as
+  // "stable" by comparing the mean of the newest half to the oldest half:
+  // averaging drops the cliff into the flat years before it.
+  describe('shapes observed in the wild', () => {
+    it('catches a field that was steady for years and then abandoned', () => {
+      // A standard picklist: 100% for five windows, then 24%.
+      const trend = trendFrom([100, 100, 100, 100, 100, 24]);
+
+      expect(trend!.direction).toBe('falling');
+    });
+
+    it('catches a field that declined steadily to nothing', () => {
+      const trend = trendFrom([68, 40, 13, 31, 7, 1]);
+
+      expect(trend!.direction).toBe('falling');
+    });
+
+    it('leaves a field that dipped only in the newest window alone', () => {
+      // Still overwhelmingly used; one softer window is not abandonment.
+      const trend = trendFrom([100, 100, 100, 100, 100, 84]);
+
+      expect(trend!.direction).toBe('stable');
+    });
+  });
+
+  // A single window is a small sample. One reading must not be able to
+  // manufacture a trend on its own.
+  it('does not let one outlying window decide the direction', () => {
+    const steadyWithBlip = trendFrom([95, 95, 0, 95, 95, 95]);
+
+    expect(steadyWithBlip!.direction).toBe('stable');
+  });
+
+  it('has no opinion when there is only one stratum', () => {
+    expect(trendFrom([50])).toBeUndefined();
+    expect(trendFrom([])).toBeUndefined();
+  });
+
+  it('reads two strata as the change between them', () => {
+    expect(trendFrom([100, 0])!.deltaPp).toBe(-100);
+  });
+});

--- a/src/client/field-discovery.ts
+++ b/src/client/field-discovery.ts
@@ -15,7 +15,9 @@ import { withRetry, parallelLimit } from '../utils/rate-limited-executor.js';
 import {
   CORE_OBJECTS, DISCOVERY_CONCURRENCY, SCORING_BATCH_SIZE,
   MAX_PROMOTED_PER_OBJECT, MAX_PROMOTED_TOTAL, WELL_KNOWN_PATTERNS,
+  SAMPLE_EXCLUDED_TYPES,
 } from '../utils/discovery-constants.js';
+import { planStrata, pooledPopulation, populationIn, trendFrom } from '../utils/record-sampler.js';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -32,14 +34,31 @@ export interface ObjectCatalog {
   scoringMs: number;
   totalFields: number;
   totalRecords: number;
+  /**
+   * Records actually drawn to score this object (ADR-301). Population is an
+   * estimate from this many rows, not a census — worth reporting, because the
+   * exactness it replaced was exactness about the wrong quantity.
+   */
+  sampledRecords: number;
 }
 
 export interface DiscoveryStats {
   objectsDiscovered: number;
+  /** Core objects the startup sweep intends to cover. */
+  objectsExpected: number;
+  /** Core objects not yet discovered. Empty once ready. */
+  pendingObjects: string[];
   totalFieldsSeen: number;
   totalPromoted: number;
   totalMs: number;
   ready: boolean;
+  /**
+   * Rough time left, projected from the pace so far (ADR-301). Present only
+   * while discovery is running and at least one object has landed to project
+   * from — a caller deciding whether to wait needs a number, and "unknown" is
+   * an honest answer before there is any evidence to base one on.
+   */
+  etaMs?: number;
   errors: string[];
 }
 
@@ -52,6 +71,8 @@ export class FieldDiscovery {
   private startupPromise: Promise<void> | null = null;
   private errors: string[] = [];
   private totalMs = 0;
+  /** When the startup sweep began — the basis for the ETA projection. */
+  private startedAt: number | null = null;
   private _ready = false;
 
   constructor(client: SalesforceClient, regulators?: Regulator[]) {
@@ -114,14 +135,36 @@ export class FieldDiscovery {
       totalFieldsSeen += catalog.totalFields;
       totalPromoted += catalog.promoted.length;
     }
+
+    // Only the startup sweep has a known scope to be pending against; objects
+    // discovered on demand are extra, not outstanding.
+    const pendingObjects = this._ready ? [] : CORE_OBJECTS.filter(o => !this.catalogs.has(o));
+    const done = CORE_OBJECTS.length - pendingObjects.length;
+    const eta = this.etaMs(done, pendingObjects.length);
+
     return {
       objectsDiscovered: this.catalogs.size,
+      objectsExpected: CORE_OBJECTS.length,
+      pendingObjects,
       totalFieldsSeen,
       totalPromoted,
       totalMs: this.totalMs,
       ready: this._ready,
+      ...(eta !== undefined ? { etaMs: eta } : {}),
       errors: [...this.errors],
     };
+  }
+
+  /**
+   * Project the time left from the pace so far, accounting for the objects
+   * discovered in parallel. A projection, not a promise — but a caller deciding
+   * whether to wait or fall back needs a number, and the alternative is asking
+   * them to guess.
+   */
+  private etaMs(done: number, remaining: number): number | undefined {
+    if (this._ready || this.startedAt === null || done === 0 || remaining === 0) return undefined;
+    const perObject = (Date.now() - this.startedAt) / done;
+    return Math.round((perObject * remaining) / DISCOVERY_CONCURRENCY);
   }
 
   /** Discover an object on-demand (if not already cached). */
@@ -142,6 +185,7 @@ export class FieldDiscovery {
 
   private async discoverCoreObjects(): Promise<void> {
     const start = Date.now();
+    this.startedAt = start;
 
     const tasks = CORE_OBJECTS.map((obj) => async () => {
       try {
@@ -190,33 +234,9 @@ export class FieldDiscovery {
         : undefined,
     }));
 
-    // 3. Population scoring
+    // 3. Population scoring, from a stratified sample (ADR-301)
     const scoringStart = Date.now();
-    const scorable = candidates.filter(f => f.nillable && isScorable(f.type));
-    let totalRecords = 0;
-
-    try {
-      const countResult = await this.queryObject(objectName, 'SELECT COUNT() FROM ' + objectName);
-      totalRecords = countResult.totalSize ?? 0;
-    } catch (err: any) {
-      this.errors.push(`${objectName} COUNT: ${err.message}`);
-    }
-
-    if (totalRecords > 0) {
-      const scoringTasks = scorable.map((field) => async () => {
-        try {
-          const result = await withRetry(
-            () => this.queryObject(objectName, `SELECT COUNT(Id) cnt FROM ${objectName} WHERE ${field.name} != null`),
-            `${objectName}.${field.name}`,
-          );
-          const count = (result.records?.[0] as any)?.cnt ?? 0;
-          field.populationPct = Math.round((count / totalRecords) * 100);
-        } catch {
-          // Non-fatal: field just won't have population data
-        }
-      });
-      await parallelLimit(scoringTasks, SCORING_BATCH_SIZE);
-    }
+    const { totalRecords, sampledRecords } = await this.scoreFromSample(objectName, candidates);
     const scoringMs = Date.now() - scoringStart;
 
     // 4. Regulate and rank
@@ -242,7 +262,92 @@ export class FieldDiscovery {
       scoringMs,
       totalFields: candidates.length,
       totalRecords,
+      sampledRecords,
     };
+  }
+
+  /**
+   * Score every candidate from one stratified sample of records (ADR-301).
+   *
+   * Costs a query per stratum rather than a query per field: a wide projection
+   * reads every selectable field at once, and the distribution is computed in
+   * memory. The sample carries values, so a boolean can be scored by how it
+   * splits and a field's usage can be tracked across time — neither of which a
+   * `COUNT(... WHERE f != null)` can see.
+   *
+   * Mutates `candidates` with populationPct / strataPopulation / trend, and
+   * reports what it drew from.
+   */
+  private async scoreFromSample(
+    objectName: string,
+    candidates: FieldCandidate[],
+  ): Promise<{ totalRecords: number; sampledRecords: number }> {
+    // One aggregate answers both "how many?" and "over what span?".
+    let totalRecords = 0;
+    let spanFrom = NaN;
+    let spanTo = NaN;
+    try {
+      const agg = await this.queryObject(
+        objectName,
+        `SELECT COUNT(Id) total, MIN(CreatedDate) spanFrom, MAX(CreatedDate) spanTo FROM ${objectName}`,
+      );
+      const row = (agg.records?.[0] ?? {}) as any;
+      totalRecords = row.total ?? 0;
+      spanFrom = Date.parse(row.spanFrom);
+      spanTo = Date.parse(row.spanTo);
+    } catch (err: any) {
+      this.errors.push(`${objectName} sample probe: ${err.message}`);
+      return { totalRecords: 0, sampledRecords: 0 };
+    }
+
+    if (totalRecords === 0) return { totalRecords, sampledRecords: 0 };
+
+    // Only fields population is a meaningful question for. A non-nillable field
+    // is 100% populated by definition — a fact about the schema that says
+    // nothing about use — so it stays unscored, as it always has (ADR-300).
+    // Flags are the exception: never null, but how they split is real evidence.
+    const scorable = candidates.filter(f =>
+      (f.nillable && isScorable(f.type)) || f.computationType === 'flag');
+    if (scorable.length === 0) return { totalRecords, sampledRecords: 0 };
+
+    // A wide SELECT can't carry compound, binary or long-text fields.
+    const projectable = candidates.filter(f => !SAMPLE_EXCLUDED_TYPES.includes(f.type.toLowerCase()));
+    const projection = projectable.map(f => f.name).join(', ');
+    if (!projection) return { totalRecords, sampledRecords: 0 };
+
+    const strata = planStrata(spanFrom, spanTo);
+    const iso = (ms: number) => new Date(ms).toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+    const samples: Array<Array<Record<string, unknown>>> = strata.map(() => []);
+    const tasks = strata.map((stratum, i) => async () => {
+      const bounds = [`CreatedDate >= ${iso(stratum.from)}`];
+      if (stratum.to !== undefined) bounds.push(`CreatedDate < ${iso(stratum.to)}`);
+      const soql =
+        `SELECT ${projection} FROM ${objectName} ` +
+        `WHERE ${bounds.join(' AND ')} LIMIT ${stratum.limit}`;
+      try {
+        const res = await withRetry(() => this.queryObject(objectName, soql), `${objectName} stratum ${i}`);
+        samples[i] = (res.records ?? []) as Array<Record<string, unknown>>;
+      } catch (err: any) {
+        // A window that fails leaves a gap in the trend, not a broken catalog.
+        this.errors.push(`${objectName} stratum ${i}: ${err.message}`);
+      }
+    });
+    await parallelLimit(tasks, SCORING_BATCH_SIZE);
+
+    const drawn = samples.filter(s => s.length > 0);
+    if (drawn.length === 0) return { totalRecords, sampledRecords: 0 };
+
+    for (const field of scorable) {
+      const isFlag = field.computationType === 'flag';
+      field.populationPct = pooledPopulation(samples, field.name, isFlag);
+      // Only windows that returned records describe an era; an empty one is a
+      // gap in the evidence, not a field nobody filled in.
+      field.strataPopulation = drawn.map(s => populationIn(s, field.name, isFlag));
+      field.trend = trendFrom(field.strataPopulation);
+    }
+
+    return { totalRecords, sampledRecords: samples.reduce((a, s) => a + s.length, 0) };
   }
 
   /** Enforce global budget — demote lowest-scoring promoted fields across objects. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,11 @@ class SalesforceServer {
         name: 'Field Discovery Stats',
         description: stats.ready
           ? `Discovery status: ${stats.objectsDiscovered} objects, ${stats.totalPromoted} promoted fields`
-          : 'Discovery status: in progress',
+          // Progress, not a bare "wait": a caller deciding whether to block or
+          // fall back needs to know how much is left (ADR-301).
+          : `Discovery status: in progress — ${stats.objectsExpected - stats.pendingObjects.length}` +
+            `/${stats.objectsExpected} objects` +
+            (stats.etaMs !== undefined ? `, ~${Math.ceil(stats.etaMs / 1000)}s remaining` : ''),
         mimeType: 'application/json',
       }];
 
@@ -194,6 +198,16 @@ class SalesforceServer {
           custom: s.field.custom,
           score: s.score,
           populationPct: s.field.populationPct,
+          // "47%, falling" and "93%, flat" are different facts about a field,
+          // and only one is worth acting on. A single density number cannot
+          // tell them apart (ADR-301).
+          ...(s.field.trend ? { trend: s.field.trend.direction, trendPp: s.field.trend.deltaPp } : {}),
+          // The evidence behind the trend, oldest window first. This is the
+          // Tier 2 view — the one that carries rationale — and a direction the
+          // reader cannot check is a direction they have to take on faith.
+          ...(includeAll && s.field.strataPopulation
+            ? { strataPopulation: s.field.strataPopulation }
+            : {}),
           adjustments: s.adjustments.map(a => `${a.delta > 0 ? '+' : ''}${a.delta} ${a.reason}`),
         });
 
@@ -201,6 +215,10 @@ class SalesforceServer {
           objectName: catalog.objectName,
           totalFields: catalog.totalFields,
           totalRecords: catalog.totalRecords,
+          // Population is estimated from this many records, not counted over
+          // all of them (ADR-301). Say so, rather than presenting an estimate
+          // with the authority of a census.
+          sampledRecords: catalog.sampledRecords,
           ...(includeAll
             ? { fields: catalog.fields.map(s => ({ ...describe(s), promoted: s.promoted })) }
             : { promoted: catalog.promoted.map(describe) }),

--- a/src/utils/discovery-constants.ts
+++ b/src/utils/discovery-constants.ts
@@ -16,6 +16,56 @@ export const DISCOVERY_CONCURRENCY = 3;
 /** Max concurrent population scoring queries per object. */
 export const SCORING_BATCH_SIZE = 5;
 
+// ── ADR-301 sampling ─────────────────────────────────────────────────
+
+/**
+ * Creation-time windows a sample is drawn across.
+ *
+ * Enough to see a trend, few enough to stay cheap: each stratum costs one
+ * query, and the whole point of sampling is that scoring an object costs
+ * queries-per-stratum rather than queries-per-field.
+ */
+export const SAMPLE_STRATA = 6;
+
+/** Records to sample per object, spread across the strata by weight. */
+export const SAMPLE_TOTAL = 300;
+
+/**
+ * Floor on any single stratum's sample, including the oldest.
+ *
+ * This is the tail ADR-301 calls mandatory. Fields can be alive only in old
+ * records, and a stratum sampled at zero reports those fields as unused —
+ * indistinguishable from not existing. Also keeps the per-stratum population
+ * precise enough to read a trend from.
+ */
+export const MIN_STRATUM_SAMPLE = 25;
+
+/**
+ * Geometric weighting toward recent records: each stratum draws this many times
+ * the sample of the one before it. >1 means the newest stratum is the largest.
+ *
+ * The question being answered is what this org populates *now*, so recent
+ * practice counts for more — but the weighting is gentle, because the tail is
+ * evidence too, not noise to be suppressed.
+ */
+export const RECENCY_WEIGHT_RATIO = 1.5;
+
+/**
+ * Field types SOQL will not accept in a wide projection. Compound fields
+ * (address, location) must be selected via their components, base64 bodies
+ * can't be bulk-selected, and long text areas blow up the response.
+ */
+export const SAMPLE_EXCLUDED_TYPES = ['address', 'location', 'base64', 'textarea'];
+
+/**
+ * Drop in population, in percentage points, between the oldest and newest half
+ * of the sample before a field is treated as being abandoned.
+ *
+ * Sampling error on a stratum is a few points; this is set well clear of it, so
+ * the signal means a practice changed rather than a coin landed badly.
+ */
+export const DRIFT_THRESHOLD_PP = 30;
+
 /** Max promoted fields per object (hard cap above the tail-curve knee). */
 export const MAX_PROMOTED_PER_OBJECT = 40;
 

--- a/src/utils/field-regulator.ts
+++ b/src/utils/field-regulator.ts
@@ -8,6 +8,7 @@
  */
 
 import { ComputationType } from './field-type-map.js';
+import type { FieldTrend } from './record-sampler.js';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -23,6 +24,15 @@ export interface FieldCandidate {
   populationPct?: number;
   /** Active picklist values, for categorical fields. Undefined otherwise. */
   picklistValues?: string[];
+  /**
+   * Population within each sampled creation-time window, oldest first (ADR-301).
+   * A by-product of stratified sampling, and the only place drift is visible:
+   * `populationPct` alone cannot tell a steadily-used field from one that was
+   * mandatory for years and has since been abandoned.
+   */
+  strataPopulation?: number[];
+  /** Direction of travel derived from strataPopulation. */
+  trend?: FieldTrend;
 }
 
 export interface ScoreAdjustment {
@@ -120,6 +130,51 @@ export const autoPopulatedRegulator: Regulator = (field) => {
   return null;
 };
 
+/**
+ * Demotion for a field the sample never once saw populated (ADR-301).
+ *
+ * Without this the other regulators rescue it: a checkbox nobody has ever
+ * ticked still collects +5 for being filterable, scores positive, and promotes
+ * — which makes the boolean signal inert, since scoring it honestly at 0%
+ * changes nothing. Only exactly zero qualifies; a field at 3% is rare, not
+ * abandoned, and sparse custom flags are precisely what the catalog is for.
+ *
+ * This is only sayable because the field was *measured*. An unscored field is
+ * silent, not zero, and must not be demoted for it.
+ */
+export const unusedRegulator: Regulator = (field) => {
+  if (field.populationPct !== 0) return null;
+  return {
+    regulator: 'unused',
+    delta: -50,
+    reason: 'no sampled record populates this field',
+  };
+};
+
+/**
+ * Demotion for fields falling out of use (ADR-301).
+ *
+ * Population density alone cannot separate a field the org still fills in from
+ * one it abandoned: a field that was mandatory for years and dead for the last
+ * few averages out to a middling number that ranks alongside a genuinely
+ * steady field. The average describes no record that ever existed. Only the
+ * trend across creation time tells them apart.
+ *
+ * The penalty is half the drop, so it scales with how decisively the practice
+ * changed rather than firing at one fixed strength. Rising fields get no
+ * matching boost: coming into use is already reflected in the recency-weighted
+ * density, and paying for it twice would promote a field on the strength of a
+ * few recent records.
+ */
+export const driftRegulator: Regulator = (field) => {
+  if (field.trend?.direction !== 'falling') return null;
+  return {
+    regulator: 'drift',
+    delta: Math.round(field.trend.deltaPp / 2),
+    reason: `usage falling (${field.trend.deltaPp}pp across the sampled span)`,
+  };
+};
+
 // ── Pipeline ─────────────────────────────────────────────────────────
 
 export const DEFAULT_REGULATORS: Regulator[] = [
@@ -129,6 +184,8 @@ export const DEFAULT_REGULATORS: Regulator[] = [
   qualityBoostRegulator,
   typeRelevanceRegulator,
   autoPopulatedRegulator,
+  unusedRegulator,
+  driftRegulator,
 ];
 
 /** Score a single field through all regulators. */

--- a/src/utils/record-sampler.ts
+++ b/src/utils/record-sampler.ts
@@ -1,0 +1,192 @@
+/**
+ * ADR-301 Record Sampler — plan a stratified sample, read population from it.
+ *
+ * ADR-300 measured population with one aggregate per field. That is expensive
+ * enough to force the signal thin — one question per field, nullable fields
+ * only — and, worse, it is time-blind: a count over every record returns a
+ * single number for the object's whole history. A field that was mandatory for
+ * six years and dead for three averages out to a number describing no record
+ * that ever existed.
+ *
+ * Sampling inverts the economics: a few queries reading many fields over some
+ * records, instead of many queries reading one field over all records. The
+ * sample carries values rather than null-counts, so the richer signals — how a
+ * boolean actually splits, how usage moves over time — come free.
+ *
+ * Everything here is pure. The queries live in field-discovery; this module
+ * decides what to ask for and what the answers mean.
+ */
+
+import {
+  SAMPLE_STRATA, SAMPLE_TOTAL, MIN_STRATUM_SAMPLE, RECENCY_WEIGHT_RATIO,
+  DRIFT_THRESHOLD_PP,
+} from './discovery-constants.js';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+/** One creation-time window to sample, oldest first. */
+export interface Stratum {
+  /** Inclusive lower bound, ms since epoch. */
+  from: number;
+  /** Exclusive upper bound, ms since epoch. The newest stratum has none. */
+  to?: number;
+  /** How many records to draw from this window. */
+  limit: number;
+}
+
+/** Population of one field within one stratum, 0-100. */
+export type StratumPopulation = number;
+
+export interface FieldTrend {
+  /**
+   * Change in population between the oldest and newest half of the sample, in
+   * percentage points. Negative means the field is falling out of use.
+   */
+  deltaPp: number;
+  direction: 'rising' | 'falling' | 'stable';
+}
+
+// ── Stratum planning ─────────────────────────────────────────────────
+
+/**
+ * Geometric weights, oldest to newest. The newest stratum draws the largest
+ * sample because recent practice answers the question being asked; the oldest
+ * still draws one because it is the only witness to fields that have since been
+ * abandoned.
+ */
+export function stratumWeights(count: number, ratio = RECENCY_WEIGHT_RATIO): number[] {
+  const raw = Array.from({ length: count }, (_, i) => Math.pow(ratio, i));
+  const total = raw.reduce((a, b) => a + b, 0);
+  return raw.map(w => w / total);
+}
+
+/**
+ * Split a creation span into weighted, sampled windows.
+ *
+ * Boundaries derive from the observed span, so the same org plans the same
+ * sample on every run — a promotion can be explained after the fact rather than
+ * blamed on the day's network timing.
+ *
+ * Degenerate spans collapse to a single window: an object whose records were
+ * all created in the same instant has no time dimension to stratify, and
+ * pretending otherwise would issue several queries that each return the same
+ * rows.
+ */
+export function planStrata(
+  spanFromMs: number,
+  spanToMs: number,
+  opts: { strata?: number; total?: number; minPerStratum?: number } = {},
+): Stratum[] {
+  const strata = opts.strata ?? SAMPLE_STRATA;
+  const total = opts.total ?? SAMPLE_TOTAL;
+  const minPer = opts.minPerStratum ?? MIN_STRATUM_SAMPLE;
+
+  if (!Number.isFinite(spanFromMs) || !Number.isFinite(spanToMs) || spanToMs <= spanFromMs || strata < 2) {
+    return [{ from: spanFromMs, limit: Math.max(total, minPer) }];
+  }
+
+  const weights = stratumWeights(strata);
+  const width = (spanToMs - spanFromMs) / strata;
+
+  return weights.map((w, i) => {
+    const from = spanFromMs + width * i;
+    const isNewest = i === strata - 1;
+    return {
+      from,
+      // The newest window is left open so records created after the span was
+      // measured — during discovery itself — are not silently outside it.
+      ...(isNewest ? {} : { to: spanFromMs + width * (i + 1) }),
+      limit: Math.max(minPer, Math.round(total * w)),
+    };
+  });
+}
+
+// ── Reading population out of a sample ───────────────────────────────
+
+/** True when a sampled value counts as "someone filled this in". */
+export function isPopulated(value: unknown): boolean {
+  return value !== null && value !== undefined && value !== '';
+}
+
+/**
+ * Population of a field within one stratum's records, 0-100.
+ *
+ * Booleans are measured by how often they are *true*, not by being non-null.
+ * A checkbox is never null, so null-counting scores every checkbox 100% — a
+ * fact about the schema carrying no information about use. How it splits is the
+ * real signal, and it is only visible because the sample carries values.
+ */
+export function populationIn(
+  records: Array<Record<string, unknown>>,
+  fieldName: string,
+  isFlag: boolean,
+): StratumPopulation {
+  if (records.length === 0) return 0;
+  const hits = records.filter(r => (isFlag ? r[fieldName] === true : isPopulated(r[fieldName]))).length;
+  return Math.round((hits / records.length) * 100);
+}
+
+/**
+ * Population across the whole sample, 0-100.
+ *
+ * Pooled rather than averaged over strata: the sample is *allocated* by
+ * recency weight, so pooling already weights recent practice more heavily.
+ * Averaging the per-stratum figures instead would throw that away and hand
+ * every era equal say.
+ */
+export function pooledPopulation(
+  strataRecords: Array<Array<Record<string, unknown>>>,
+  fieldName: string,
+  isFlag: boolean,
+): StratumPopulation {
+  const all = strataRecords.flat();
+  return populationIn(all, fieldName, isFlag);
+}
+
+/**
+ * Direction of travel, from the per-stratum populations.
+ *
+ * A least-squares fit across every window, reported as the change the fitted
+ * line covers end to end. Two cheaper measures were tried against real data
+ * and both lie:
+ *
+ * Comparing the newest stratum to the oldest reads two small samples and calls
+ * the difference a trend — noise in either endpoint invents drift that isn't
+ * there.
+ *
+ * Comparing the mean of the newest half to the oldest half is robust but
+ * blind to a cliff, because it averages the drop into the flat years before
+ * it. A field observed at [100, 100, 100, 100, 100, 24] — steady for years,
+ * then abandoned — comes out at -25pp and reads "stable", which is exactly
+ * backwards. A field declining steadily [68, 40, 13, 31, 7, 1] does the same.
+ *
+ * A regression uses every point, so no single window can manufacture a trend,
+ * and it tracks the trajectory rather than flattening it.
+ */
+export function trendFrom(
+  strataPopulations: StratumPopulation[],
+  thresholdPp = DRIFT_THRESHOLD_PP,
+): FieldTrend | undefined {
+  const n = strataPopulations.length;
+  if (n < 2) return undefined;
+
+  const meanX = (n - 1) / 2;
+  const meanY = strataPopulations.reduce((a, b) => a + b, 0) / n;
+
+  let covariance = 0;
+  let variance = 0;
+  for (let i = 0; i < n; i++) {
+    covariance += (i - meanX) * (strataPopulations[i] - meanY);
+    variance += (i - meanX) ** 2;
+  }
+
+  // variance is zero only when n < 2, already handled.
+  const slopePerStratum = covariance / variance;
+  const deltaPp = Math.round(slopePerStratum * (n - 1));
+
+  const direction = deltaPp <= -thresholdPp ? 'falling'
+    : deltaPp >= thresholdPp ? 'rising'
+      : 'stable';
+
+  return { deltaPp, direction };
+}


### PR DESCRIPTION
Implements ADR-301 (#90). The catalog can now tell an abandoned field from a used one.

## What changed

Population was measured with one `COUNT(Id) WHERE f != null` per field. That is replaced by a stratified sample: a handful of wide `SELECT`s across creation-time windows, weighted toward recent records, with a mandatory tail in the oldest window. Distribution is computed in memory.

**Measured on the reference org:** discovery of all six core objects **7.4s → 2.2s**; Account **~130 queries → 7**.

## The cost was never the real problem

A count over every record returns one number for an object's whole history, so it cannot separate a field the org still fills in from one it abandoned. Both average to something middling. Sampling makes the time dimension affordable — and because a sample carries *values* rather than null-counts, two signals arrive for free.

**Booleans are scored by how often they're `true`.** A checkbox is never null, so null-counting scored every checkbox 100% — a fact about the schema that says nothing about use. All 22 on the reference org sample 1–9% true. None promote.

**Drift is visible per era, and a regulator demotes fields falling out of use.** Standard fields a single number could not tell apart:

| field | per-era population | verdict |
|---|---|---|
| `BillingCity` | `[100, 96, 97, 98, 44, 5]` | **falling -90pp**, rank 64 → 96 |
| `BillingState` | `[68, 40, 13, 31, 7, 1]` | **falling -59pp** |
| `Type` | `[100, 100, 100, 100, 100, 24]` | **falling -54pp** |
| `Industry` | `[100, 100, 100, 100, 100, 84]` | stable -11pp, still promoted |

Falling detections went 4 → 12, while `Industry` and `Phone` stayed stable — more sensitive without becoming trigger-happy.

## The trend measure earned its complexity

It's a least-squares fit across every window. Two cheaper measures were tried **against that same real data** and both lied:

- **Endpoints** let noise in one small sample invent drift.
- **Newest-half mean vs oldest-half mean** is robust but blind to a cliff — it averages the drop into the flat years before it. It called both `Type` and `BillingState` *"stable"* while they were being abandoned in plain sight. That's what the first draft of this PR shipped, until the live probe printed the raw strata.

## Also

- **A field the sample never once saw populated is demoted**, rather than rescued by its type bonus. Without this, scoring a dead checkbox honestly at 0% changed nothing — it still collected +5 for "filterable" and promoted, making the new boolean signal inert.
- **Pending state reports progress and an ETA** projected from the pace so far, instead of a bare "not ready". The estimate is withheld until an object has landed to project from — inventing one is worse than admitting there's nothing to go on.
- **`/all` carries the per-stratum populations** behind each trend. A direction the reader can't check is one they have to take on faith.

## Honest notes

- Population is now an **estimate**, where it was exact. The exactness was of the wrong quantity, but the catalog says `sampledRecords` rather than presenting an estimate with the authority of a census.
- **Weighting encodes a judgement** — that recent practice matters more. Right for query authoring, wrong for auditing history. The mandatory tail bounds that; it doesn't remove it.
- The discovery tests were rewritten to **simulate records** rather than mock query strings. A fake returning canned counts can only confirm arithmetic it was handed; the thing under test is what the sampler reads *out of records*.

557 tests green, lint and build clean. Verified end-to-end against the live org, not just in tests.
