### PR TITLE
fix: defer Salesforce auth + discovery until after the MCP handshake

### DIFF
--- a/src/__tests__/server-startup.test.ts
+++ b/src/__tests__/server-startup.test.ts
@@ -62,6 +62,21 @@ describe('SalesforceServer startup', () => {
     expect(conn.login).toHaveBeenCalledTimes(1);
   });
 
+  // The regression this guards: eager warmup() in the constructor did network
+  // I/O before the MCP handshake finished, which under Claude Desktop's built-in
+  // Node (Electron UtilityProcess) raced the initialize response and hung the
+  // connection. Auth must not start until run() defers it to the post-initialize
+  // hook. Construction — and time passing — must touch nothing on the wire.
+  it('does not authenticate on construction', async () => {
+    const server = new SalesforceServer();
+    jest.spyOn(server['fieldDiscovery'], 'startAsync').mockImplementation(() => {});
+
+    await new Promise(process.nextTick);
+
+    expect(conn.login).not.toHaveBeenCalled();
+    expect(conn.authorize).not.toHaveBeenCalled();
+  });
+
   it('does not authenticate again when a tool call follows startup', async () => {
     const server = new SalesforceServer();
     jest.spyOn(server['fieldDiscovery'], 'startAsync').mockImplementation(() => {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,11 @@ class SalesforceServer {
     );
 
     this.sfClient = new SalesforceClient();
-    this.sfClient.warmup();
+    // Auth warmup is NOT kicked off here. Doing network I/O this early — before
+    // the client has finished the MCP handshake — races the initialize response
+    // on stdout under Claude Desktop's UtilityProcess runtime and can leave the
+    // handshake unanswered ("unable to connect"). run() defers it to the
+    // post-initialize hook instead; see run().
     this.cache = new SessionCache();
     this.cacheMiddleware = new CacheMiddleware(this.cache);
     this.fieldDiscovery = new FieldDiscovery(this.sfClient);
@@ -362,14 +366,29 @@ class SalesforceServer {
   }
 
   async run() {
-    // Connect MCP transport FIRST so the handshake completes immediately.
-    // Salesforce auth happens lazily on the first tool call — if it fails
-    // or hangs, it shouldn't block the MCP initialize/capabilities exchange.
+    // Defer all Salesforce work (auth warmup + field discovery) until AFTER the
+    // client acknowledges the handshake with notifications/initialized. Firing
+    // it in the constructor or right after connect() puts network I/O in the
+    // same tick window as the initialize response; under Claude Desktop's
+    // built-in Node (Electron UtilityProcess) that race can leave the response
+    // unflushed, so the client times out with "unable to connect". Waiting for
+    // the initialized notification lets the handshake settle on a quiet event
+    // loop first.
+    //
+    // The convergence contract still holds: warmup() kicks off auth, background
+    // init runs discovery and announces the resource-list refetch — just a beat
+    // later. And auth stays lazy-safe: every tool handler calls
+    // ensureInitialized(), so data converges on first use even if a client never
+    // sends the initialized notification. Set before connect() so the handler is
+    // registered when the notification arrives.
+    this.server.oninitialized = () => {
+      this.sfClient.warmup();
+      this.startBackgroundInit();
+    };
+
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
     console.error('Salesforce MCP server running on stdio');
-
-    this.startBackgroundInit();
   }
 }
 


### PR DESCRIPTION
## Problem

Loading the 0.7.0 `.mcpb` into Claude Desktop fails with **"unable to connect to extension server. please try disabling and re-enabling the extension"**, and the config panel is unreachable.

Diagnosis from the CD logs (`~/.config/Claude/logs/`):

- CD runs the extension on its **built-in Electron Node via UtilityProcess** — not the user's system Node — because the manifest declares no `compatibility.runtimes.node` (`Using UtilityProcess ... compatibility matrix is not specified`).
- On the failing launches the transport connects (`running on stdio` reaches CD) but the `initialize` **response on stdout never does**, and the eager auth call neither succeeds nor fails — it hangs. The client times out after 60s.
- Every successful handshake in months of history is `0.2.0`; the hangs begin the moment 0.7.0 is installed.

**Root cause:** 0.7.0 fires eager auth warmup in the constructor and starts field discovery immediately after `connect()`. That network I/O runs in the same tick window as the `initialize` response; under the UtilityProcess runtime the response can be left unflushed. 0.2.0 was lazy-only, so it never raced the handshake.

The `.mcpb` itself is valid and the server runs correctly under standalone Node 20/22/26 — this is a startup-timing regression, not a packaging fault.

## Fix

Defer `warmup()` and `startBackgroundInit()` to the SDK's `oninitialized` hook (fires on `notifications/initialized`), so the handshake settles on a quiet event loop before any Salesforce work starts.

**Convergence contract preserved:** warmup still runs, discovery still runs, and the resource-list `listChanged` notification still fires — a beat later. Auth stays lazy-safe: every tool handler calls `ensureInitialized()`, so data converges on first use even if a client never sends the notification.

## Tests

- Adds "does not authenticate on construction" to `server-startup.test.ts`, guarding against reintroducing eager warmup.
- `make check` green: 558 tests pass, build clean.
- End-to-end handshake sim confirms the `initialize` response goes out before any auth/discovery, and Salesforce work begins only after `notifications/initialized`.

## Caveat

Not yet confirmed against the real Claude Desktop UtilityProcess runtime (it can't be reproduced standalone). Reasoned from the logs; validate by loading the rebuilt `.mcpb`.