### PR TITLE
fix: start under Electron UtilityProcess (drop require.main entrypoint guard)

### DIFF
--- a/src/__tests__/server-startup.test.ts
+++ b/src/__tests__/server-startup.test.ts
@@ -27,7 +27,7 @@ jest.mock('jsforce', () => ({
   Connection: jest.fn().mockImplementation(() => conn),
 }));
 
-import { SalesforceServer } from '../index';
+import { SalesforceServer, shouldAutostart } from '../index';
 
 let errSpy: jest.SpyInstance;
 const originalEnv = process.env;
@@ -203,5 +203,25 @@ describe('SalesforceServer startup', () => {
 
       expect(server['server']['_capabilities'].resources).toMatchObject({ listChanged: true });
     });
+  });
+});
+
+// Regression guard for the v0.7.2 fix. The extension failed to start under
+// Claude Desktop's Electron UtilityProcess because startup was gated on
+// `require.main === module`, which is false there. The gate must depend on Jest
+// only, so the server starts in every real runtime (node CLI, npx, and the
+// UtilityProcess where require.main !== module) and stays quiet under tests.
+describe('shouldAutostart', () => {
+  it('starts in a real runtime regardless of require.main (UtilityProcess case)', () => {
+    expect(shouldAutostart({})).toBe(true);
+  });
+
+  it('does not start when imported by the Jest test suite', () => {
+    expect(shouldAutostart({ JEST_WORKER_ID: '1' })).toBe(false);
+  });
+
+  it('is not running a server inside this very test process', () => {
+    // We are under Jest, so the module-load autostart must have been suppressed.
+    expect(shouldAutostart()).toBe(false);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -394,9 +394,25 @@ class SalesforceServer {
 
 export { SalesforceServer };
 
-// Only start a server when run as the entrypoint, so tests can import the
-// class without binding stdio or opening a Salesforce connection.
-if (require.main === module) {
+/**
+ * Whether to auto-start the server when this module is loaded.
+ *
+ * This deliberately does NOT gate on `require.main === module`. Under Claude
+ * Desktop's built-in Node (Electron UtilityProcess) the entry module is loaded
+ * such that `require.main !== module`, so that guard silently skipped startup:
+ * the server never constructed, the MCP handshake was never answered, and the
+ * extension failed with "unable to connect" — while the exact same build worked
+ * as a plain `node`/`npx` CLI (where `require.main === module` holds). Jest is
+ * the only context that imports this module without wanting a running server,
+ * so gate on that instead. See the release notes for v0.7.2.
+ */
+export function shouldAutostart(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return !env.JEST_WORKER_ID;
+}
+
+if (shouldAutostart()) {
   const server = new SalesforceServer();
-  server.run().catch(console.error);
+  server.run().catch((error) => console.error('Fatal error running server:', error));
 }


### PR DESCRIPTION
## Problem

The `.mcpb` fails to load in Claude Desktop — "unable to connect to extension server" — and the extension is unconfigurable. Works fine as a `node`/`npx` CLI (and via manual `claude_desktop_config.json`), so it looked like a host bug, but sibling extensions (Jira, Confluence, Google Workspace) run under the same runtime and connect fine.

## Root cause

CD runs node-type extensions through its **built-in Node (Electron UtilityProcess)**, where the entry module is loaded such that **`require.main !== module`**. Startup was gated on `if (require.main === module)` — added after 0.2.0 so tests could import `SalesforceServer` without binding stdio. Under UtilityProcess that guard is false, so the block was skipped: the server never constructed, the handshake was never answered, CD timed out. `node`/`npx` set `require.main === module`, so the CLI path always worked. This is the 0.2.0 → 0.7.0 regression (0.2.0 had no such guard).

A diagnostic build made it conclusive — `module loaded` fired, but `constructing SalesforceServer` never did, with the event loop alive throughout.

## Fix

Gate autostart on **Jest** instead of `require.main` (extracted as `shouldAutostart(env)`), the only context that imports this module without wanting a running server. Verified by reproducing `require.main !== module` locally (`node -e "require('build/index.js')"`): the server now starts and answers `initialize`.

## Tests

- `shouldAutostart` regression guards: starts in a real runtime regardless of `require.main`; stays quiet under Jest.
- `make check` green: 561 tests, build clean.

Ships as v0.7.2.